### PR TITLE
Cloudcleaner

### DIFF
--- a/cloudcleaner/__init__.py
+++ b/cloudcleaner/__init__.py
@@ -1,0 +1,57 @@
+"""Tool for automatically cleaning up AWS resources no one claims or that aren't in use."""
+import os
+from datetime import datetime, timezone
+
+from slacker import Slacker
+
+import cloudcleaner
+import cloudcleaner.aws
+import cloudcleaner.azure
+import cloudcleaner.common
+
+
+def get_slack():
+    """Get a Slack API object."""
+    cloudcleaner.common.check_test()
+    return Slacker(token=os.environ['SLACK_TOKEN'])
+
+
+def get_users():
+    """Get all the users who could take ownership of resources."""
+    cloudcleaner.common.check_test()
+
+    slack = get_slack()
+    users = []
+    for user in slack.users.list().body['members']:
+        users.append(user['name'])
+
+    return users
+
+
+def get_time():
+    """Get the current time.
+
+    This is an extra function here to make getting the time be easily monkeypatched out.
+    """
+    return datetime.now(timezone.utc)
+
+
+def run(dry_run, match_str):
+    """Run cloudcleaner and return a JSON report of the actions."""
+    now = get_time()
+    report = {
+        'now': now.isoformat(),
+        'aws': {'categorized_instances': {}, 'instance_actions': {}, 'keypair_actions': {}},
+        'azure': {'resource_group_actions': {}, 'categorized_resource_groups': {}}}
+    for Cleaner in (cloudcleaner.aws.AwsCleaner, cloudcleaner.azure.AzureCleaner):
+        try:
+            this_cleaner = Cleaner(now)
+            this_cleaner.collect_resources(get_users())
+            this_cleaner.clean_resources(dry_run, match_str)
+            report.update(this_cleaner.make_report())
+        except Exception as ex:
+            # If Unsafe then immediately raise
+            if isinstance(ex, cloudcleaner.common.UnsafeWithoutEnvVar):
+                raise
+            report.update({'error': repr(ex)})
+    return report

--- a/cloudcleaner/aws.py
+++ b/cloudcleaner/aws.py
@@ -1,0 +1,358 @@
+import collections
+import logging
+from datetime import timedelta
+
+import boto3
+import botocore.exceptions
+
+from cloudcleaner.common import (
+    AbstractCleaner,
+    check_test,
+    delta_to_str,
+    EXPIRE_WARNING_TIME,
+    parse_delta)
+
+
+aws_region_names = [
+    {
+        'name': 'US West (N. California)',
+        'id': 'us-west-1'
+    },
+    {
+        'name': 'US West (Oregon)',
+        'id': 'us-west-2'
+    },
+    {
+        'name': 'US East (N. Virginia)',
+        'id': 'us-east-1'
+    },
+    {
+        'name': 'South America (Sao Paulo)',
+        'id': 'sa-east-1'
+    },
+    {
+        'name': 'EU (Ireland)',
+        'id': 'eu-west-1'
+    },
+    {
+        'name': 'EU (Frankfurt)',
+        'id': 'eu-central-1'
+    },
+    {
+        'name': 'Asia Pacific (Tokyo)',
+        'id': 'ap-northeast-1'
+    },
+    {
+        'name': 'Asia Pacific (Singapore)',
+        'id': 'ap-southeast-1'
+    },
+    {
+        'name': 'Asia Pacific (Sydney)',
+        'id': 'ap-southeast-2'
+    },
+    {
+        'name': 'Asia Pacific (Seoul)',
+        'id': 'ap-northeast-2'
+    },
+    {
+        'name': 'Asia Pacific (Mumbai)',
+        'id': 'ap-south-1'
+    },
+    {
+        'name': 'US East (Ohio)',
+        'id': 'us-east-2'
+    }]
+
+
+def get_service_resources(service, resource):
+    """Return resources in every region for the given boto3 service and resource type."""
+    check_test()
+
+    for acct in [boto3.session.Session()]:
+        for region in aws_region_names:
+            for instance in getattr(acct.resource(service, region_name=region['id']), resource).all():
+                yield instance
+
+
+def get_instances():
+    """Get all EC2 instances in all regions."""
+    yield from get_service_resources('ec2', 'instances')
+
+
+def get_keypairs():
+    """Get all EC2 key pairs in all regions."""
+    yield from get_service_resources('ec2', 'key_pairs')
+
+
+def get_stacks():
+    """Get all AWS CloudFormation stacks in all regions."""
+    yield from get_service_resources('cloudformation', 'stacks')
+
+
+def has_tag(instance, tag):
+    """Find if an ec2 instance has a particular tag."""
+    if instance.tags is None:
+        return False
+    return any(d['Key'] == tag for d in instance.tags)
+
+
+def get_tag(instance, tag, default=None):
+    """Get the tag by the current name from the ec2 tags, returning a defaul if not found."""
+    if instance.tags is None:
+        return False
+    for d in instance.tags:
+        if tag == d['Key']:
+            return d['Value']
+    return default
+
+
+def add_tag(instance, tag, value, dry_run):
+    """Add a tag to the given ec2 instance."""
+    catch_aws_dryrun(instance.create_tags, Tags=[{'Key': tag, 'Value': value}], DryRun=dry_run)
+
+
+def categorize_instance(instance, now, users):
+    """Categorize an ec2 instance based on it's attributes."""
+    state = instance.state['Name']
+
+    if state == 'terminated':
+        return 'terminated'
+
+    # Ignore instances which are just starting or that are already stopping.
+    if state in ['pending', 'shutting-down', 'stopping']:
+        return 'changing_state'
+
+    if state not in ['running', 'stopped']:
+        return 'unknown_state'
+
+    # Skip all ccm instances
+    if has_tag(instance, 'aws:cloudformation:stack-id'):
+        return 'ccm'
+
+    # Ignore all instances less than 30 minutes old if they don't have an owner
+    # and expiration. Not being tagged is just people not getting to it yet.
+    # Billed by the hour for AWS anyways.
+    uptime = now - instance.launch_time
+
+    # While instances less than 30 minutes old may have owner, expiration we're
+    # still going to consider them in the grace period, since a user could still
+    # be editing typos post-launch.
+    if uptime <= timedelta(minutes=30):
+        return 'new'
+
+    # Check if tagged with launcher. If not, kill with prejudice.
+    if has_tag(instance, 'owner'):
+        if get_tag(instance, 'owner') not in users:
+            return 'invalid_owner'
+    else:
+        # Ownerless instances with an expiration that are stopped we let sit around
+        # (they cost nothing) As a grace period.
+        if not (state == 'stopped' and has_tag(instance, 'expiration')):
+            return 'no_owner'
+
+    # Check if tagged with an expiration. If not, mark to have one added
+    if not has_tag(instance, 'expiration'):
+        return 'needs_expiration'
+
+    expiration_str = get_tag(instance, 'expiration')
+    if expiration_str == 'never':
+        return 'never_expire'
+
+    # Has expiration passed?
+    try:
+        expiration = parse_delta(expiration_str)
+    except ValueError:
+        return 'invalid_expiration'
+
+    # 0 minutes before expiration is probably invalid / unintentional.
+    if expiration == timedelta():
+        return 'invalid_expiration'
+
+    if uptime >= expiration:
+        return 'expired'
+
+    if expiration - uptime <= EXPIRE_WARNING_TIME:
+        if not has_tag(instance, 'owner'):
+            return 'no_owner_stopped'
+        else:
+            return 'expire_soon'
+
+    if not has_tag(instance, 'owner'):
+        return 'no_owner_stopped'
+    else:
+        return 'ok'
+
+
+def get_categorized_instances(now, users):
+    """Categorize all ec2 instances using the given now timestamp and user list."""
+    categorized = collections.defaultdict(list)
+
+    for instance in get_instances():
+        try:
+            category = categorize_instance(instance, now, users)
+        except Exception:
+            logging.exception('Got an exception categorizing instance %s', instance)
+            category = 'error'
+        categorized[category].append(instance)
+        print("Categorized", instance, "as", category)
+
+    return categorized
+
+
+def catch_aws_dryrun(func, *args, **kwargs):
+    """TODO(cmaloney): This is a great big hack because AWS endpoints with boto3 when passed 'DryRun'.
+
+    throw an exception which we need to catch and passify for proper operation. Should really make an
+    "instance" class and EC2 is one implementation of it. Azure GCE should be alternate
+    implementations of it.
+    """
+    if kwargs.get('DryRun') is not True:
+        func(*args, **kwargs)
+        return
+
+    try:
+        func(*args, **kwargs)
+    except botocore.exceptions.ClientError as ex:
+        if ex.response['Error'].get('Code') == "DryRunOperation":
+            return
+        raise
+
+
+def set_expiration(instance, now, delta, dry_run):
+    """Set an expiration time on an instance baed on how long it's already been running."""
+    expiration_str = delta_to_str(now - instance.launch_time + delta)
+    add_tag(instance, 'expiration', expiration_str, dry_run)
+
+
+def take_instance_action(category, instance, now, dry_run):
+    """Given a categoized instance, take some measurable action on it (terminate it, tag it, etc.)."""
+    if category in ['error', 'ok', 'ccm', 'changing_state', 'new', 'terminated', 'unknown_state', 'no_owner_stopped',
+                    'expire_soon']:
+        return 'noop'
+    if category in ['no_owner', 'invalid_owner']:
+        # Stop and add a 23  hour 50 minute expiration from current time.
+        catch_aws_dryrun(instance.stop, DryRun=dry_run)
+        set_expiration(instance, now, timedelta(hours=24), dry_run)
+
+        # For invalid owner also set a "message" tag to invalid_owner
+        if category == 'invalid_owner':
+            add_tag(instance, 'message', 'Owner does not exist in slack as a username', dry_run)
+
+        return 'stop'
+
+    if category in ['needs_expiration', 'invalid_expiration']:
+        # Add a 50 min expiration from current time
+        set_expiration(instance, now, timedelta(minutes=50), dry_run)
+
+        if category == 'invalid_expiration':
+            add_tag(instance, 'message', 'Invalid / unparseable expiration. Reset to default.', dry_run)
+
+        return 'add_expire'
+
+    if category == 'expired':
+        catch_aws_dryrun(instance.terminate, DryRun=dry_run)
+        return 'terminated'
+
+    return 'unknown_category'
+
+
+def take_keypair_action(keypair, match_str, stack_list, dry_run):
+    """Take an action on a keypair and report what happened."""
+    name = keypair.key_name
+    if match_str and match_str in name and name not in stack_list:
+        if not dry_run:
+            keypair.delete()
+        return 'delete'
+    return 'noop'
+
+
+def perform_keypair_actions(match_str, dry_run):
+    """Categorize and take action on all keypairs in the AWS account.
+
+    For all keypairs, if keypair name contains match_str
+    and there is no such stack, then delete the keypair.
+    """
+    all_stacks = [stack.stack_name for stack in get_stacks()]
+    actions = collections.defaultdict(list)
+    for keypair in get_keypairs():
+        try:
+            taken = take_keypair_action(keypair, match_str, all_stacks, dry_run)
+        except Exception:
+            logging.exception('Got an exception while checking keypair %s', keypair)
+            taken = 'error'
+        actions[taken].append(keypair)
+
+    return actions
+
+
+def perform_instance_actions(categorized_instances, now, dry_run):
+    """Take the categoized instances, and perform the currently needed actions on them."""
+    actions = collections.defaultdict(list)
+    for category, instance_list in categorized_instances.items():
+        for instance in instance_list:
+            try:
+                taken = take_instance_action(
+                    category=category,
+                    instance=instance,
+                    now=now,
+                    dry_run=dry_run)
+            except Exception:
+                logging.exception('Got an exception taking action for category %s on instance %s', category, instance)
+                taken = 'error'
+            actions[taken].append(instance)
+
+    return actions
+
+
+def instance_to_json(instance, now):
+    """Convert an ec2 instance to a json repot about it."""
+    return {
+        'id': instance.instance_id,
+        'state': instance.state['Name'],
+        'tags': dict(((tag['Key'], tag['Value']) for tag in instance.tags) if instance.tags else {}),
+        'launch_time': instance.launch_time.isoformat(),
+        'uptime': delta_to_str(now - instance.launch_time),
+        'owner': get_tag(instance, 'owner'),
+        'expiration': get_tag(instance, 'expiration') if has_tag(instance, 'expiration') else None,
+        'instance_type': instance.instance_type
+    }
+
+
+def make_json_report(now, categorized_instances, instance_actions, keypair_actions):
+    """ Generate a json report which will get stored for future data analysis.
+    Args:
+        now: datetime.datetime object
+        categorized_instances: dict(str, list(ec2.Instance))
+        instance_actions: dict(str, list(ec2.Instance))
+        keypair_actions: dict(str, list(ec2.KeyPairInfo))
+    """
+    json_report = {}
+
+    json_report['categorized_instances'] = {}
+    for category, instance_list in categorized_instances.items():
+        json_report['categorized_instances'][category] = [instance_to_json(i, now) for i in instance_list]
+
+    json_report['instance_actions'] = {}
+    for category, instance_list in instance_actions.items():
+        json_report['instance_actions'][category] = [instance_to_json(i, now) for i in instance_list]
+
+    json_report['keypair_actions'] = {}
+    for category, key_list in keypair_actions.items():
+        json_report['keypair_actions'][category] = [k.key_name for k in key_list]
+
+    return {'aws': json_report}
+
+
+class AwsCleaner(AbstractCleaner):
+
+    def collect_resources(self, users):
+        self.categorized_instances = get_categorized_instances(self.now, users)
+
+    def clean_resources(self, dry_run, match_str):
+        self.instance_actions = perform_instance_actions(
+            self.categorized_instances, self.now, dry_run)
+        self.keypair_actions = perform_keypair_actions(match_str, dry_run)
+
+    def make_report(self):
+        return make_json_report(
+            self.now, self.categorized_instances, self.instance_actions, self.keypair_actions)

--- a/cloudcleaner/azure.py
+++ b/cloudcleaner/azure.py
@@ -1,0 +1,270 @@
+import collections
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from azure.common.credentials import ServicePrincipalCredentials
+from azure.mgmt.resource.resources import ResourceManagementClient
+from azure.mgmt.resource.resources.v2017_05_10.models.resource_group import ResourceGroup
+from azure.monitor import MonitorClient
+
+from cloudcleaner.common import (
+    AbstractCleaner,
+    CI_OWNER,
+    delta_to_str,
+    EXPIRE_WARNING_TIME,
+    parse_delta)
+
+
+def get_resource_mgmt_client():
+    return ResourceManagementClient(ServicePrincipalCredentials(
+        client_id=os.environ['AZURE_CLIENT_ID'],
+        secret=os.environ['AZURE_CLIENT_SECRET'],
+        tenant=os.environ['AZURE_TENANT_ID']), os.environ['AZURE_SUBSCRIPTION_ID'])
+
+
+def get_monitor_client():
+    return MonitorClient(ServicePrincipalCredentials(
+        client_id=os.environ['AZURE_CLIENT_ID'],
+        secret=os.environ['AZURE_CLIENT_SECRET'],
+        tenant=os.environ['AZURE_TENANT_ID']), os.environ['AZURE_SUBSCRIPTION_ID'])
+
+
+def tag_creation_time(resource_group: ResourceGroup):
+    """Creation time is not natively tracked by azure, so look through the event log and find the
+    farthest back time that shows the resource group being created (may potentially be the last
+    time the resource group was updated). If no such time is found, then creation time is assumed
+    to be the furthest bound of the log search (30 days ago)
+    """
+    logging.info('creation_time tag not found; scanning logs for {} creation'.format(resource_group.name))
+    oldest_log_time = datetime.now(timezone.utc) - timedelta(days=30)  # logs can only be queried a month back
+    log_filter = " and ".join([
+        'eventTimestamp ge {}'.format(oldest_log_time.isoformat()),
+        'eventChannels eq Operation',
+        'resourceGroupName eq {}'.format(resource_group.name)])
+    select = ','.join([
+        'operationName',
+        'eventTimestamp',
+        'subStatus'])
+    creation_time = None
+    for event in get_monitor_client().activity_logs.list(filter=log_filter, select=select):
+        if 'Update resource group' != event.operation_name.localized_value:
+            continue
+        if event.sub_status.value == 'Created':
+            logging.info('Creation time found at {}'.format(event.event_timestamp.isoformat()))
+            if creation_time is None or event.event_timestamp < creation_time:
+                creation_time = event.event_timestamp
+    if creation_time is None:
+        creation_time = oldest_log_time
+    logging.info('No creation time found in logs; setting creation time to {}'.format(creation_time.isoformat()))
+    update_tags(get_resource_mgmt_client(), resource_group,
+                {'creation_time': creation_time.replace(tzinfo=None).isoformat()})
+
+
+def update_tags(rmc, resource_group: ResourceGroup, tags):
+    """when a resource group is patched, is completely deletes
+    all existing tags, thus read tags first
+    """
+    if resource_group.tags is None:
+        resource_group.tags = dict()
+    resource_group.tags.update(tags)
+    rmc.resource_groups.patch(resource_group.name, {
+        'tags': resource_group.tags,
+        'location': resource_group.location}, raw=True)
+
+
+def get_creation_time(resource_group: ResourceGroup):
+    """ Extracts datetime object from creation_time tag within ResourceGoup"""
+    try:
+        return datetime.strptime(
+            resource_group.tags['creation_time'], '%Y-%m-%dT%H:%M:%S.%f').replace(tzinfo=timezone.utc)
+    except Exception as ex:
+        raise ValueError('creation_time could not be parsed') from ex
+
+
+def categorize_resource_group(resource_group: ResourceGroup, now, users):
+    """ Puts resource groups into the following categories
+    """
+    categories = set()
+    tags = resource_group.tags
+    if tags is None:
+        tags = {}
+
+    if 'creation_time' not in tags:
+        categories.add('needs_creation_time')
+    else:
+        try:
+            uptime = now - get_creation_time(resource_group)
+        except ValueError:
+            categories.add('invalid_creation_time')
+
+    if 'owner' in tags:
+        if tags['owner'] not in users + [CI_OWNER]:
+            categories.add('invalid_owner')
+    else:
+        categories.add('no_owner')
+
+    # Check if tagged with an expiration. If not, mark to have one added
+    if 'expiration' not in tags:
+        categories.add('needs_expiration')
+        return categories
+
+    expiration_str = tags['expiration']
+    if expiration_str == 'never':
+        categories.add('never_expire')
+        return categories
+
+    # Has expiration passed?
+    try:
+        expiration = parse_delta(expiration_str)
+    except ValueError:
+        categories.add('invalid_expiration')
+        return categories
+
+    # expiration of zero minutes is probably invalid / unintentional.
+    if expiration == timedelta():
+        categories.add('invalid_expiration')
+        return categories
+
+    # need uptime here after, so return early
+    if 'needs_creation_time' in categories or 'invalid_creation_time' in categories:
+        return categories
+
+    if uptime >= expiration:
+        categories.add('expired')
+    elif expiration - uptime <= EXPIRE_WARNING_TIME:
+        categories.add('expire_soon')
+
+    if len(categories) == 0:
+        return {'ok'}
+
+    return categories
+
+
+def get_categorized_resource_groups(rmc, now, users):
+    categorized = collections.defaultdict(list)
+
+    for resource_group in rmc.resource_groups.list():
+        try:
+            categories = categorize_resource_group(resource_group, now, users)
+        except Exception:
+            logging.exception('Got an exception categorizing resource_group %s', resource_group.name)
+            categories = ['error']
+        for category in categories:
+            categorized[category].append(resource_group)
+        logging.info('Categorized {} as {}'.format(resource_group.name, str(categories)))
+
+    return categorized
+
+
+def take_resource_group_action(rmc, category, resource_group):
+    """Azure does not instantaneously validate that operations can be performed,
+    thus if a user does not have the authorization to delete a resource, that will not be
+    reported until the poller completes
+    """
+    if category == 'error':
+        return 'noop'
+
+    if category in ['no_owner', 'invalid_owner']:
+        add_tags = {'owner': CI_OWNER}
+        if category == 'invalid_owner':
+            # tag so that in case the owner gets feed back if the wrong handle was provided
+            add_tags.update({'error_message': 'invalid owner was set'})
+        update_tags(rmc, resource_group, add_tags)
+        return 'owned_by_cloudcleaner'
+
+    if category in ['needs_expiration', 'invalid_expiration']:
+        update_tags(rmc, resource_group, {'expiration': '2h'})
+        if category == 'invalid_expiration':
+            update_tags(rmc, resource_group, {'message': 'Invalid / unparseable expiration. Reset to default.'})
+        return 'add_expiration'
+
+    if category in ['needs_creation_time', 'invalid_creation_time']:
+        tag_creation_time(resource_group)
+        return 'add_creation_time'
+
+    if category == 'expired':
+        delete_resource_group(rmc, resource_group.name)
+        return 'deleted'
+
+    return 'unknown_category'
+
+
+def delete_resource_group(rmc, resource_group_name):
+    """ Seperate function for threading and easy mocking
+    """
+    rmc.resource_groups.delete(resource_group_name, raw=True)
+
+
+def perform_resource_group_actions(rmc, categorized_resource_groups):
+    actions = collections.defaultdict(list)
+    for category, resource_group_list in categorized_resource_groups.items():
+        for resource_group in resource_group_list:
+            try:
+                taken = take_resource_group_action(
+                    rmc=rmc,
+                    category=category,
+                    resource_group=resource_group)
+            except Exception:
+                logging.exception(
+                    'Got an exception taking action for category %s on resource_group %s', category, resource_group)
+                taken = 'error'
+            actions[taken].append(resource_group)
+
+    return actions
+
+
+def resource_group_to_json(resource_group, now):
+    """Convert an resource group to a json repot about it."""
+    out = {
+        'name': resource_group.name,
+        'state': resource_group.properties.provisioning_state,
+    }
+    if resource_group.tags is not None:
+        out.update({
+            'creation_time': resource_group.tags.get('creation_time', 'unset'),
+            'owner': resource_group.tags.get('owner', 'unset'),
+            'expiration': resource_group.tags.get('expiration', 'unset')})
+        if out['creation_time'] != 'unset':
+            creation_datetime = get_creation_time(resource_group)
+            out.update({'uptime': delta_to_str(now - creation_datetime)})
+    return out
+
+
+def make_json_report(now, categorized_resource_groups, resource_group_actions):
+    """ Generate a json report which will get stored for future data analysis.
+    Args:
+        now: datetime.datetime object
+        categorized_resource_groups: dict(str, list(ResourceGroup))
+        resource_group_actions: dict(str, list(ResourceGroup))
+    """
+    json_report = {}
+
+    json_report['categorized_resource_groups'] = {}
+    for category, resource_group_list in categorized_resource_groups.items():
+        json_report['categorized_resource_groups'][category] = [
+            resource_group_to_json(rg, now) for rg in resource_group_list]
+
+    json_report['resource_group_actions'] = {}
+    for category, resource_group_list in resource_group_actions.items():
+        json_report['resource_group_actions'][category] = [
+            resource_group_to_json(rg, now) for rg in resource_group_list]
+
+    return {'azure': json_report}
+
+
+class AzureCleaner(AbstractCleaner):
+    def __init__(self, now):
+        super().__init__(now)
+        self.rmc = get_resource_mgmt_client()
+
+    def collect_resources(self, users):
+        self.categorized_resource_groups = get_categorized_resource_groups(
+            self.rmc, self.now, users)
+
+    def clean_resources(self, dry_run, match_str):
+        self.actions = perform_resource_group_actions(
+            self.rmc, self.categorized_resource_groups)
+
+    def make_report(self):
+        return make_json_report(self.now, self.categorized_resource_groups, self.actions)

--- a/cloudcleaner/common.py
+++ b/cloudcleaner/common.py
@@ -1,0 +1,133 @@
+import abc
+import os
+import re
+from datetime import timedelta
+
+CI_OWNER = 'cloudcleaner'
+EXPIRE_WARNING_MINUTES = 10
+EXPIRE_WARNING_TIME = timedelta(minutes=EXPIRE_WARNING_MINUTES)
+
+
+class UnsafeWithoutEnvVar(Exception):
+    """Thrown when cloudlceaner aborts because not all safety checks have been satisfied."""
+    pass
+
+
+def check_test():
+    """Validate that dangerous APIs aren't called unless we explicitly approve that this is not a test.
+
+    This keeps us from doing things like getting real ec2 instances to act on when we mean to be testing.
+    The envrionment variable is THIS_IS_NOT_A_TEST
+    """
+    if not os.environ.get('THIS_IS_NOT_A_TEST'):
+        raise UnsafeWithoutEnvVar()
+
+
+def delta_to_str(delta):
+    """Convert a timedelta to a string format which is reversable.
+    Takes a datetime.timedelta object and converts it into a string
+    that is parseable by parse_delta
+    """
+    # NOTE: Rounds up to nearest minute)
+    units = [('m', 60), ('h', 60), ('d', 24), ('w', 7)]
+
+    remaining = delta.total_seconds()
+
+    delta_str = ''
+
+    negative = remaining < 0
+
+    def add_negative():
+        return '-' + delta_str if negative else delta_str
+
+    # Only handle things in the future for simplicity in testing.
+    if negative:
+        remaining = -remaining
+
+    # Print 0 minutes as the base case.
+    if remaining == 0:
+        return '0m'
+
+    for i in range(0, len(units)):
+        unit, count = units[i]
+
+        remainder = int(remaining % count)
+        remaining = int(remaining // count)
+
+        # Round up the first unit (seconds) into minutes.
+        if i == 0:
+            if remainder > 0:
+                remaining += 1
+        else:
+            assert i > 0
+            if remainder != 0:
+                delta_str = "{}{}{}".format(remainder, units[i - 1][0], delta_str)
+
+        # No need to go further / captured it all, so long as we've printed at
+        # least minutes.
+        if remaining == 0 and i > 0:
+            return add_negative()
+
+    # Print the last unit with all the remaining count.
+    delta_str = "{}{}{}".format(remaining, units[-1][0], delta_str)
+
+    return add_negative()
+
+
+def parse_delta(delta):
+    """Parse a timedelta string format into a python timedelta object.
+    Takes a delta string like that constructed in delta_to_str and converts
+    it into a datetime.timedelta object
+    """
+    assert delta != 'never'
+    possible_args = ['weeks', 'days', 'hours', 'minutes']
+
+    # Find all the <count> <unit> patterns, expand the count + units to build a timedelta.
+    chunk_regex = r'(\d+)\s*(\D+)\s*'
+    kwargs = {}
+    for count, unit in re.findall(chunk_regex, delta, re.I):
+        unit = unit.strip()
+        int_count = int(count)
+        found_unit = False
+        # match so that units can be given as single letters instead of whole words
+        for arg in possible_args:
+            if arg.startswith(unit):
+                kwargs[arg] = int_count
+                found_unit = True
+                break
+
+        if not found_unit:
+            raise ValueError("Unknown unit '{}' when parsing '{}'".format(unit, delta))
+
+    return timedelta(**kwargs)
+
+
+class AbstractCleaner(metaclass=abc.ABCMeta):
+    """Simple wrapper for storing state between cleaning steps
+    as well as defining a standard interface for all providers
+    """
+    def __init__(self, now):
+        self.now = now
+
+    @abc.abstractmethod
+    def collect_resources(self, users):
+        pass
+
+    @abc.abstractmethod
+    def clean_resources(self, dry_run, match_str):
+        pass
+
+    @abc.abstractmethod
+    def make_report(self):
+        pass
+
+
+class MockCleaner(AbstractCleaner):
+    def collect_resources(self, users, name='Mock'):
+        pass
+
+    def clean_resources(self, dry_run, match_str):
+        pass
+
+    def make_report(self):
+        return {}

--- a/cloudcleaner/main.py
+++ b/cloudcleaner/main.py
@@ -1,0 +1,73 @@
+"""Main function and code to bind the various components together to a runable cloud cleaner cli."""
+import argparse
+import json
+import logging
+import sys
+
+import jinja2
+from pkg_resources import resource_string
+
+import cloudcleaner
+import cloudcleaner.common
+
+LOGGING_FORMAT = '[%(asctime)s|%(name)s|%(levelname)s]: %(message)s'
+
+
+def make_html_report(report):
+    """Render an HTML report of the cloudcleaner findings."""
+    return jinja2.Template(resource_string(__name__, "report.html.jinja").decode()).render(report)
+
+
+def write_file(name, contents):
+    """Write a file without leaking an fd to Garbage Collection."""
+    with open(name, 'w') as f:
+        f.write(contents)
+
+
+def do_main(argument_array):
+    """Build the argument parser than run cloudcleaner with the args."""
+    logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--be-ruthless', action='store_true')
+    parser.add_argument('--key-match', action='store')
+    args = parser.parse_args(argument_array)
+
+    dry_run = not args.be_ruthless
+
+    if args.key_match and len(args.key_match) < 5:
+        print('To avoid matching to too many key names, use at least 5 characters to match with.')
+        sys.exit(1)
+
+    report = cloudcleaner.run(dry_run, args.key_match)
+
+    # Write out a machine-readable report
+    write_file("report.json", json.dumps(report, sort_keys=True, indent=4, separators=(',', ':')))
+
+    # Write out a human-readable report
+    write_file('cloudcleaner.html', make_html_report(report))
+
+    return report
+
+
+def main_wrapper(func, *args):
+    """Wrap main and catch common exceptions, giving them better error messages."""
+    try:
+        return func(*args)
+    except cloudcleaner.common.UnsafeWithoutEnvVar:
+        print("ERROR: THIS_IS_NOT_A_TEST environment variable must be set to "
+              "run cloudcleaner. This helps guard against accidentally running "
+              "the code on their machine and it calling APIs which could "
+              "potentially take out an entire AWS production account.")
+        sys.exit(1)
+
+
+def main():
+    """Run cloudcleaner and generate a report. Copy the report to stdout to make things easier in jenkins."""
+    report = main_wrapper(do_main, sys.argv[1:])
+
+    # HACK(cmaloney): Write report.json to the screen since in some environments the artifacts
+    # aren't available.
+    if report:
+        print("##### BEGIN report.json #####")
+        print(json.dumps(report, sort_keys=True, indent=4, separators=(',', ':')))
+        print("##### END report.json #####")

--- a/cloudcleaner/report.html.jinja
+++ b/cloudcleaner/report.html.jinja
@@ -1,0 +1,79 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>CloudCleaner Instance Report</title>
+</head>
+
+<body>
+<h1>CloudCleaner AWS Instance Report</h1>
+<h2>Summary</h2>
+<h3>Actions:</h3>
+<p>
+{% for action, instance_list in aws.instance_actions|dictsort %}
+<b>{{ action }} </b>: {{ instance_list|length }} instances<br />
+{% endfor %}
+</p>
+<h3>States:</h3>
+<p>
+{% for category, instance_list in aws.categorized_instances|dictsort %}
+<b>{{ category }} </b>: {{ instance_list|length }} instances<br />
+{% endfor %}
+</p>
+<h2>Instances By State</h2>
+{% for category, instance_list in aws.categorized_instances|dictsort %}
+<h3>{{ category }} </h3>
+<ul>
+  {% for instance in instance_list %}
+  <li>
+  <b>owner:</b> {{ instance.owner }}<br />
+  <b>id: </b> {{ instance.id }}<br />
+  <b>uptime: </b> {{ instance.uptime }}<br />
+  <b>launch_time: </b> {{ instance.launch_time }}<br />
+  <b>expiration: </b> {{ instance.expiration_time }}<br />
+  </li>
+  {% endfor %}
+</ul>
+{% endfor %}
+<h1>CloudCleaner AWS KeyPair Report</h1>
+<h2>Summary</h2>
+<h3>Actions:</h3>
+<p>
+{% for action, keypair_list in aws.keypair_actions|dictsort %}
+<b>{{ action }} </b>: {{ keypair_list|length }} keypairs<br />
+{% endfor %}
+</p>
+<h1>CloudCleaner Azure Resource Group Report</h1>
+<h2>Summary</h2>
+<h3>Actions:</h3>
+<p>
+{% for action, group_list in azure.resource_group_actions|dictsort %}
+<b>{{ action }} </b>: {{ group_list|length }} resource groups<br />
+{% endfor %}
+</p>
+<h3>States:</h3>
+<p>
+{% for category, group_list in azure.categorized_resource_groups|dictsort %}
+<b>{{ category }} </b>: {{ group_list|length }} resource groups<br />
+{% endfor %}
+</p>
+<h2>Instances By State</h2>
+{% for category, group_list in azure.categorized_resource_groups|dictsort %}
+<h3>{{ category }} </h3>
+<ul>
+  {% for group in group_list %}
+  <li>
+  <b>owner:</b> {{ group.owner }}<br />
+  <b>name: </b> {{ group.name }}<br />
+  <b>uptime: </b> {{ group.uptime }}<br />
+  <b>creation_time: </b> {{ group.creation_time }}<br />
+  <b>expiration: </b> {{ group.expiration }}<br />
+  </li>
+  {% endfor %}
+</ul>
+{% endfor %}
+
+</body>
+</html>

--- a/cloudcleaner/test_aws.py
+++ b/cloudcleaner/test_aws.py
@@ -1,0 +1,517 @@
+"""Test the overall behavior of cloudcleaner."""
+import json
+import logging
+import os.path
+from copy import copy
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import cloudcleaner
+import cloudcleaner.aws
+import cloudcleaner.azure
+import cloudcleaner.main
+
+pytestmark = [pytest.mark.usefixtures('mocked_azure')]
+
+now = datetime(2016, 1, 8, 1, 20, 30, 14, timezone.utc)
+instance_id = 0
+
+
+@pytest.fixture
+def mocked_azure(monkeypatch):
+    monkeypatch.setattr(cloudcleaner.azure, 'AzureCleaner', cloudcleaner.common.MockCleaner)
+
+
+class _MockInstance():
+    """Mock AWS EC2 instance for testing with subset of boto3 api."""
+
+    def __init__(self, instance_id, state, tags, launch_time):
+        assert isinstance(state, str)
+        assert isinstance(tags, dict)
+
+        self.instance_id = instance_id
+        self.launch_time = launch_time
+        self.__tags = tags
+        self.__state = state
+        self.actions_taken = []
+        self.accessed_properties = set()
+        self.instance_type = "m3.testing"
+
+    def create_tags(self, Tags, DryRun):  # noqa: N803, copying AWS API
+        new_tags = dict()
+        for tag_dict in Tags:
+            new_tags[tag_dict['Key']] = tag_dict['Value']
+
+        if DryRun:
+            return
+
+        self.__tags.update(new_tags)
+
+        self.actions_taken.append(('create_tags', new_tags))
+
+    @property
+    def tags(self):
+        self.accessed_properties.add('tags')
+        tags_list = []
+        for k, v in self.__tags.items():
+            tags_list.append({'Key': k, 'Value': v})
+        return tags_list
+
+    @property
+    def state(self):
+        self.accessed_properties.add('state')
+        return {
+            'Name': self.__state
+        }
+
+    # DryRun is a mandatory arg to try to help enforce that we always pass it
+    # through.
+    def terminate(self, DryRun):  # noqa: N803, copying AWS API
+        if DryRun:
+            return
+        self.actions_taken.append(('terminated', DryRun))
+        self.__state = 'terminated'
+
+    # DryRun is a mandatory arg to try to help enforce that we always pass it
+    # through.
+    def stop(self, DryRun):  # noqa: N803, copying AWS API
+        if DryRun:
+            return
+        self.actions_taken.append(('stop', DryRun))
+        self.__state = 'stopped'
+
+    def __str__(self):
+        return str(self.instance_id)
+
+    def __repr__(self):
+        return "<test_cloudcleaner._MockInstance {}>".format(self.instance_id)
+
+    def __lt__(self, that):
+        return self.instance_id < that.instance_id
+
+
+class _MockKeyPair:
+    def __init__(self, name):
+        self.key_name = name
+
+    def delete(self):
+        pass
+
+
+class _MockStack:
+    def __init__(self, name):
+        self.stack_name = name
+
+
+def make_instance(state='running', tags=dict(), launch_delta=timedelta(minutes=45)):
+    """Create a mock instance with the given time since launch."""
+    global instance_id
+    instance_id += 1
+    return _MockInstance(
+        instance_id=instance_id,
+        tags=tags,
+        state=state,
+        launch_time=now - launch_delta)
+
+
+def test_categorize():
+    """Make sure instances in specific states fall into the expected categories."""
+    def check(category, **instance_args):
+        users = ['cody', 'foo', 'owner']
+        instance = make_instance(**instance_args)
+        assert cloudcleaner.aws.categorize_instance(instance, now, users) == category
+
+        # Categorizing an instance shouldn't take any actions
+        assert instance.actions_taken == []
+
+    def check_run_stop(category, **instance_args):
+        check(category, state='running', **instance_args)
+        check(category, state='stopped', **instance_args)
+
+    def check_owned(category, **instance_args):
+        tags = instance_args.get('tags', dict())
+        tags['owner'] = 'cody'
+        instance_args['tags'] = tags
+        check_run_stop(category, **instance_args)
+
+    # Check the different categories other than running are handled as expected
+    check('terminated', state='terminated')
+    check('terminated', state='terminated', launch_delta=timedelta(minutes=0))
+    check('terminated', state='terminated', launch_delta=timedelta(minutes=100))
+
+    check('changing_state', state='pending')
+    check('changing_state', state='shutting-down')
+    check('no_owner', state='stopped')  # stopped instance which has been up longer
+    # than 30 minutes means no owner, instance will be deleted.
+
+    check('unknown_state', state='some-new-state')
+
+    # Test Running, stopped where expiration is the key.
+    check_run_stop('new', launch_delta=timedelta(minutes=0))
+    check_run_stop('new', launch_delta=timedelta(minutes=15))
+    check_run_stop('new', launch_delta=timedelta(minutes=30))
+    # Instances younger than 30 minutes are always new.
+    check_owned('new', launch_delta=timedelta(minutes=30), tags={'expiration': '30m'})
+    check_run_stop('no_owner', launch_delta=timedelta(minutes=31))
+    check_run_stop('no_owner')
+
+    # CCM tagged instances are out of scope
+    check_run_stop('ccm', tags={'aws:cloudformation:stack-id': 'foo'})
+
+    # Running or stopped with owner + expiration info
+    check_run_stop('needs_expiration', tags={'owner': 'cody'})
+    check_owned('needs_expiration')
+    check_run_stop('needs_expiration', tags={'owner': 'foo'})
+    check_run_stop('no_owner', tags={'ower': 'owner'})
+    check_run_stop('no_owner', tags={'ower': 'cody'})
+
+    # Not in users -> invalid_owner
+    check_run_stop('invalid_owner', tags={'owner': 'test'})
+
+    check_owned('invalid_expiration', tags={'expiration': '30hrs'})
+    check_owned('invalid_expiration', tags={'expiration': 'foo'})
+    check_owned('invalid_expiration', tags={'expiration': 'foo5123'})
+
+    check_owned('never_expire', tags={'expiration': 'never'})
+    check_owned('expired', launch_delta=timedelta(minutes=31), tags={'expiration': '30m'})
+    check_owned('expired', launch_delta=timedelta(minutes=100), tags={'expiration': '30m'})
+    check_owned('expired', launch_delta=timedelta(minutes=100), tags={'expiration': '1h'})
+
+    check_owned('ok', launch_delta=timedelta(minutes=31), tags={'expiration': '50m'})
+    check_owned('expire_soon', launch_delta=timedelta(minutes=40), tags={'expiration': '50m'})
+    check_owned('expire_soon', launch_delta=timedelta(minutes=40), tags={'expiration': '45m'})
+    check_owned('expire_soon', launch_delta=timedelta(minutes=40), tags={'expiration': '41m'})
+    check_owned('expired', launch_delta=timedelta(minutes=40), tags={'expiration': '40m'})
+
+    check_owned('ok', launch_delta=timedelta(hours=1), tags={'expiration': '2h'})
+    check_owned('ok', launch_delta=timedelta(hours=1), tags={'expiration': '1h15m'})
+    check_owned('ok', launch_delta=timedelta(hours=2), tags={'expiration': '300m'})
+
+
+def test_instance_to_json():
+    """Check converting an instance from python object to json works."""
+    assert cloudcleaner.aws.instance_to_json(_MockInstance('asdf', 'running', dict(), now), now) == {
+        'id': 'asdf',
+        'state': 'running',
+        'tags': {},
+        'launch_time': '2016-01-08T01:20:30.000014+00:00',
+        'uptime': '0m',
+        'owner': None,
+        'expiration': None,
+        'instance_type': 'm3.testing'
+    }
+
+    assert cloudcleaner.aws.instance_to_json(_MockInstance(
+        'asdf', 'stopped', {'owner': 'cody', 'expiration': '1m'}, now - timedelta(hours=1)), now) == {
+            'id': 'asdf',
+            'state': 'stopped',
+            'tags': {'owner': 'cody', 'expiration': '1m'},
+            'launch_time': '2016-01-08T00:20:30.000014+00:00',
+            'uptime': '1h',
+            'owner': 'cody',
+            'expiration': '1m',
+            'instance_type': 'm3.testing'}
+
+    assert cloudcleaner.aws.instance_to_json(_MockInstance(
+        'asdf', 'stopped', {'expiration': '30d2h5m'}, now - timedelta(days=10)), now) == {
+            'id': 'asdf',
+            'state': 'stopped',
+            'tags': {'expiration': '30d2h5m'},
+            'launch_time': '2015-12-29T01:20:30.000014+00:00',
+            'uptime': '1w3d',
+            'owner': None,
+            'expiration': '30d2h5m',
+            'instance_type': 'm3.testing'}
+
+
+def test_take_instance_action():
+    """Test taking actions given a category + instance. Both dry run and not."""
+    def check(category,
+              action,
+              actions_taken=list(),
+              launch_delta=timedelta(minutes=0),
+              accessed_properties=set(),
+              skip_first=False,
+              **instance_args):
+
+        instance_args['launch_delta'] = launch_delta
+        instance = make_instance(**instance_args)
+        assert cloudcleaner.aws.take_instance_action(category, instance, now, True) == action
+
+        # Taking an action shouldn't read out properties / act on them.
+        assert instance.accessed_properties == accessed_properties
+        # In dry run no actions should be taken
+        assert instance.actions_taken == []
+        assert cloudcleaner.aws.take_instance_action(category, instance, now, False) == action
+        assert instance.actions_taken == actions_taken
+
+    # All the no-op cases
+    check('ccm', 'noop')
+    check('changing_state', 'noop')
+    check('new', 'noop')
+    check('terminated', 'noop')
+    check('unknown_state', 'noop')
+
+    # If categorize puts out a bad / unexpected category
+    check('foo', 'unknown_category')
+
+    # TODO(cmaloney): Test with creation time not equal to the present, should
+    # add however much time has already elapsed to the expiration.
+    check('no_owner', 'stop', [('stop', False), ('create_tags', {'expiration': '1d'})])
+    check('needs_expiration', 'add_expire', [('create_tags', {'expiration': '50m'})])
+    check('no_owner', 'stop', [('stop', False), ('create_tags', {'expiration': '1d20m'})],
+          launch_delta=timedelta(minutes=20))
+    check('needs_expiration', 'add_expire', [('create_tags', {'expiration': '1h20m'})],
+          launch_delta=timedelta(minutes=30))
+
+    # Invalid owner (like no_owner but one additional tag.
+    invalid_owner_tag = ('create_tags', {'message': 'Owner does not exist in slack as a username'})
+    check('invalid_owner', 'stop', [('stop', False), ('create_tags', {'expiration': '1d'}), invalid_owner_tag])
+    check('invalid_owner', 'stop', [('stop', False), ('create_tags', {'expiration': '1d20m'}), invalid_owner_tag],
+          launch_delta=timedelta(minutes=20))
+
+    # Terminate an instance
+    check('expired', 'terminated', [('terminated', False)])
+    check('expired',
+          'terminated',
+          [('terminated', False)],
+          tags={'owner': 'cody'})
+
+
+def test_advance_states(monkeypatch, tmpdir):
+    """Take an instance, and trace how the state changes over time.
+
+    This makes sure that event chains happen properly (starting -> no_owner/stop -> terminate).
+    """
+    # Move to a tmpdir so report.json and cleanup.html don't litter the source tree.
+    with tmpdir.as_cwd():
+        do_test_advance_states(monkeypatch)
+
+
+def _check_instance_state(instance,
+                          expected_state,
+                          report,
+                          is_start_of_state,
+                          elapsed_time):
+    # Should always find a state for the instance
+    assert expected_state is not None
+    assert expected_state.keys() <= {'action', 'actions_taken', 'category', 'state'}
+    assert expected_state.keys() >= {'action', 'category'}
+
+    action = expected_state['action']
+    if is_start_of_state:
+        if expected_state['action'] == 'noop':
+            assert instance.actions_taken == []
+            assert 'actions_taken' not in expected_state
+        else:
+            assert instance.actions_taken == expected_state['actions_taken']
+    else:
+        assert instance.actions_taken == []
+
+    # Check to make sure the instance state matches the expected for the time window.
+    assert instance.state['Name'] == expected_state.get('state', 'running')
+
+    # Check the instance was labelled in the report as expected.
+    id_str = str(instance.instance_id)
+
+    def check_labelled_properly(section, label):
+        found = False
+        for instance in report[section].get(label, []):
+            if instance['id'] == id_str:
+                found = True
+                break
+
+        assert found, "{} was not labelled in section {} as expected. Should have been: {}.\nReport: {}".format(
+            id_str,
+            section,
+            label,
+            json.dumps(report[section], sort_keys=True, indent=4, separators=(',', ': ')))
+
+    # Category is correctoin
+    check_labelled_properly('categorized_instances', expected_state['category'])
+
+    # Action is correct. Note actions are only taken on state transition. Rest of state is no-op.
+    # That is accounted for when we set action earlier.
+    check_labelled_properly('instance_actions', action)
+
+
+def do_test_advance_states(monkeypatch):
+    """Check that advancing instances through time results in the expected states at the right times."""
+    def get_users():
+        return {'cody'}
+
+    def make_instance_tags(instance_id, tags=dict()):
+        return _MockInstance(instance_id=instance_id, launch_time=now, tags=tags, state='running')
+
+    expected_steps = dict()
+
+    # General instance expiring
+    normal_instance = make_instance_tags('id-normal', {'expiration': '4h', 'owner': 'cody'})
+    expected_steps[normal_instance] = [
+        ('0m', {'category': 'new', 'action': 'noop'}),
+        ('32m', {'category': 'ok', 'action': 'noop'}),
+        ('3h50m', {'category': 'expire_soon', 'action': 'noop'}),
+        ('4h', {
+            'category': 'expired',
+            'action': 'terminated',
+            'actions_taken': [('terminated', False)],
+            'state': 'terminated',
+        }),
+        ('4h2m', {
+            'category': 'terminated',
+            'action': 'noop',
+            'state': 'terminated'})]
+
+    # No owner
+    no_owner_instance = make_instance_tags('id-no_owner')
+    expected_steps[no_owner_instance] = [
+        ('0m', {'category': 'new', 'action': 'noop'}),
+        ('32m', {
+            'category': 'no_owner',
+            'action': 'stop',
+            'actions_taken': [('stop', False), ('create_tags', {'expiration': '1d32m'})],
+            'state': 'stopped'}),
+        ('34m', {
+            'category': 'no_owner_stopped',
+            'action': 'noop',
+            'state': 'stopped'}),
+        ('1d32m', {
+            'category': 'expired',
+            'state': 'terminated',
+            'action': 'terminated',
+            'actions_taken': [('terminated', False)]
+        }),
+        ('1d34m', {
+            'category': 'terminated',
+            'state': 'terminated',
+            'action': 'noop'
+        })]
+
+    # TODO(cmaloney): No owner gets owner after stopped, and is started again by user.
+
+    # TODO(cmaloney): No owner, gets started after stopped
+
+    # No expiration
+    no_expiration_instance = make_instance_tags('id-no_expiration', {'owner': 'cody'})
+    expected_steps[no_expiration_instance] = [
+        ('0m', {'category': 'new', 'action': 'noop'}),
+        ('32m', {
+            'category': 'needs_expiration',
+            'action': 'add_expire',
+            'actions_taken': [('create_tags', {'expiration': '1h22m'})]}),
+        ('34m', {'category': 'ok', 'action': 'noop'}),
+        ('1h12m', {'category': 'expire_soon', 'action': 'noop'}),
+        ('1h22m', {
+            'category': 'expired',
+            'action': 'terminated',
+            'actions_taken': [('terminated', False)],
+            'state': 'terminated'}),
+        ('1h24m', {'category': 'terminated', 'action': 'noop', 'state': 'terminated'})]
+
+    # CCM instance
+    ccm_instance = make_instance_tags('id-ccm', {'aws:cloudformation:stack-id': 'something'})
+    expected_steps[ccm_instance] = [('0m', {'category': 'ccm', 'action': 'noop'})]
+
+    def get_instances():
+        return list(expected_steps.keys())
+
+    # Check all step timelines start at 0 (Critical for the step finding later)
+    for instance, steps in expected_steps.items():
+        assert steps[0][0] == '0m'
+
+    # State tracking
+    clock = copy(now)
+    time_passed = timedelta()
+    step_duration = timedelta(minutes=2)  # We're running at 2 minute intervals in production.
+
+    # Make it so do_main is running in the sandbox we've prepared, clock and all.
+    monkeypatch.setattr('cloudcleaner.get_users', get_users)
+    monkeypatch.setattr('cloudcleaner.aws.get_instances', get_instances)
+    monkeypatch.setattr('cloudcleaner.aws.get_keypairs', lambda: [])
+    monkeypatch.setattr('cloudcleaner.aws.get_stacks', lambda: [])
+    monkeypatch.setattr('cloudcleaner.get_time', lambda: clock)
+
+    # For sanity since we're running CC a lot of times, and each prints a lot of lines...
+    logging.basicConfig(level=logging.WARNING)
+
+    # Make sure the build directory is clean so we only get output from the
+    # current run of do_main
+    assert not os.path.exists('cloudcleaner.html')
+    assert not os.path.exists('report.json')
+
+    while True:
+
+        # Reset instance actions_taken so that we can see what happens in this run
+        for instance in get_instances():
+            instance.actions_taken = []
+
+        # Check a dry run doesn't change the state store or mutate instance state.
+        cloudcleaner.main.do_main([])
+
+        for instance in get_instances():
+            assert instance.actions_taken == []
+
+        # Expect actual run to advance all instances. All instances should be in
+        # the most recent step they passed.
+        cloudcleaner.main.do_main(['--be-ruthless', '--key-match', 'my-ci'])
+
+        report = json.load(open('report.json'))['aws']
+        # Sorted to ensure stable results
+        for instance in sorted(get_instances()):
+
+            # Find the current step
+            cur_state = None
+            state_start_time = None
+            for time, state in expected_steps[instance]:
+                state_time = cloudcleaner.common.parse_delta(time)
+
+                # If not enough time to reach the state has passed the last state is
+                # the right one
+                if time_passed < state_time:
+                    break
+
+                cur_state = state
+                state_start_time = state_time
+
+            # TODO(cmaloney): Make a better mechanism to spy / introspect this.
+            _check_instance_state(
+                instance=instance,
+                expected_state=cur_state,
+                report=report,
+                is_start_of_state=time_passed == state_start_time,
+                elapsed_time=cloudcleaner.common.delta_to_str(time_passed))
+
+        # Make sure the html report exists
+        assert os.path.exists('cloudcleaner.html')
+
+        # Advance in time
+        clock += step_duration
+        time_passed += step_duration
+
+        # Stop after simulating 30 hours.
+        if time_passed >= timedelta(hours=30):
+            break
+
+    # TODO(cmaloney): Add test that all instances are in their end state
+
+
+def test_take_keypair_action(monkeypatch, tmpdir):
+    """Check that taking an action on a keypair acts as expected."""
+    expired_key = _MockKeyPair('test-from-my-ci-yesterday')
+    live_key = _MockKeyPair('test-from-my-ci-today')
+    untracked_key = _MockKeyPair('foo')
+
+    test_stack = _MockStack(live_key.key_name)
+
+    monkeypatch.setattr('cloudcleaner.get_users', lambda: [])
+    monkeypatch.setattr('cloudcleaner.aws.get_instances', lambda: [])
+    monkeypatch.setattr('cloudcleaner.aws.get_keypairs', lambda: [expired_key, live_key, untracked_key])
+    monkeypatch.setattr('cloudcleaner.aws.get_stacks', lambda: [test_stack])
+    with tmpdir.as_cwd():
+        cloudcleaner.main.do_main(['--be-ruthless', '--key-match', 'my-ci'])
+
+        report = json.load(open('report.json'))['aws']
+
+    assert report['keypair_actions']['delete'] == [expired_key.key_name]
+    assert sorted(report['keypair_actions']['noop']) == sorted([live_key.key_name, untracked_key.key_name])

--- a/cloudcleaner/test_azure.py
+++ b/cloudcleaner/test_azure.py
@@ -1,0 +1,381 @@
+"""Test the overall behavior of cloudcleaner."""
+import copy
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import cloudcleaner
+import cloudcleaner.aws
+import cloudcleaner.azure
+import cloudcleaner.common
+import cloudcleaner.main
+
+from cloudcleaner.azure import resource_group_to_json
+
+pytestmark = [pytest.mark.usefixtures('mocked_aws')]
+
+now = datetime(2016, 1, 8, 1, 20, 30, 14, timezone.utc)
+
+
+@pytest.fixture
+def mocked_aws(monkeypatch):
+    monkeypatch.setattr(cloudcleaner.aws, 'AwsCleaner', cloudcleaner.common.MockCleaner)
+
+
+class _MockResourceGroup:
+    def __init__(self, tags: dict, name: str='ResourceGroupTestFooBar'):
+        self.tags = tags
+        self.name = name
+        self.location = 'West US'
+        self.provisioning_state = 'Succeeded'
+
+    @property
+    def properties(self):
+        return self
+
+
+def dump_time(dt):
+    """ Timestamps must be dumped without TZinfo so that isoformat
+    doesn't add an a +HH:MM which will not be parseable
+    """
+    return dt.replace(tzinfo=None).isoformat()
+
+
+def test_categorize():
+    def check(categories: set, tags: dict):
+        users = ['testuser', 'foo', cloudcleaner.common.CI_OWNER]
+        assert set(cloudcleaner.azure.categorize_resource_group(
+            _MockResourceGroup(tags), now, users)) == categories
+
+    new = {'no_owner', 'needs_expiration', 'needs_creation_time'}
+    check(new, None)
+    check(new, {})
+
+    check(new, {'do_not_delete': True})
+
+    check({'invalid_owner', 'needs_creation_time', 'needs_expiration'}, {'owner': 'someone-who-isnt-real'})
+
+    check({'needs_creation_time', 'needs_expiration'}, {'owner': 'testuser'})
+
+    check({'never_expire', 'needs_creation_time'}, {'owner': 'testuser', 'expiration': 'never'})
+
+    check({'invalid_expiration', 'needs_creation_time'}, {'owner': 'testuser', 'expiration': 'foobar'})
+    check({'invalid_expiration', 'needs_creation_time'}, {'owner': 'testuser', 'expiration': 'tomorrow'})
+    check({'invalid_expiration', 'needs_creation_time'}, {'owner': 'testuser', 'expiration': 'three days'})
+
+    check({'needs_creation_time'}, {'owner': 'testuser', 'expiration': '2w'})
+    check({'needs_creation_time'}, {'owner': 'testuser', 'expiration': '3days'})
+    check({'needs_creation_time'}, {'owner': 'testuser', 'expiration': '99hours'})
+    check({'needs_creation_time'}, {'owner': 'testuser', 'expiration': '99 hours'})
+    check({'needs_creation_time'}, {'owner': 'testuser', 'expiration': '2 day 99 hours'})
+
+    check({'invalid_creation_time'}, {'owner': 'testuser', 'expiration': '99hours', 'creation_time': 'foobar'})
+    check({'invalid_creation_time'}, {'owner': 'testuser', 'expiration': '99hours', 'creation_time': '12-25-2015'})
+
+    expiration_str = '99hours'
+    exact_expiration_dt = now - timedelta(hours=99)  # this is the time of exact expiration
+    expire_not_soon_dt = exact_expiration_dt + (cloudcleaner.common.EXPIRE_WARNING_TIME + timedelta(minutes=1))
+    check({'ok'}, {
+        'owner': 'testuser',
+        'expiration': expiration_str,
+        'creation_time': dump_time(expire_not_soon_dt)})
+
+    expire_soon_dt = exact_expiration_dt + (cloudcleaner.common.EXPIRE_WARNING_TIME - timedelta(minutes=1))
+    check({'expire_soon'}, {
+        'owner': 'testuser',
+        'expiration': '99hours',
+        'creation_time': dump_time(expire_soon_dt)})
+
+    expired_dt = exact_expiration_dt - timedelta(minutes=1)
+    check({'expired'}, {
+        'owner': 'testuser',
+        'expiration': expiration_str,
+        'creation_time': dump_time(expired_dt)})
+
+
+class MockRmc:
+    def __init__(self, group_list=None):
+        self.group_list = group_list if group_list is not None else None
+
+    @property
+    def resource_groups(self):
+        """ rmc is only called to access resource_groups so just map it back
+        to this object to avoid creating an extra useless object
+        """
+        return self
+
+    def patch(self, name: str, tags: dict, raw=True):
+        pass
+
+    def list(self):
+        return self.group_list
+
+
+def mock_delete_resource_group(mock_rmc, resource_group_name):
+    if mock_rmc.group_list is None:
+        return
+    for i in range(len(mock_rmc.group_list)):
+        if mock_rmc.group_list[i].name == resource_group_name:
+            del mock_rmc.group_list[i]
+            return
+    raise Exception('Group {} cannot be deleted because it cannot be found'.format(resource_group_name))
+
+
+@pytest.fixture
+def mocked_rmc(monkeypatch):
+    monkeypatch.setattr(cloudcleaner.azure, 'get_resource_mgmt_client', lambda: MockRmc())
+    monkeypatch.setattr(cloudcleaner.azure, 'delete_resource_group', mock_delete_resource_group)
+
+
+def test_take_resource_group_action(monkeypatch, mocked_rmc):
+    """Test taking actions given a category + instance. Both dry run and not."""
+    monkeypatch.setattr(
+        cloudcleaner.azure, 'tag_creation_time',
+        lambda rg: rg.tags.update({'creation_time': dump_time(now - timedelta(days=30))}))
+
+    def check(category,
+              action,
+              tags,
+              expected_tags=dict()):
+
+        resource_group = _MockResourceGroup(tags)
+        assert cloudcleaner.azure.take_resource_group_action(
+            MockRmc(), category, resource_group) == action
+        assert cloudcleaner.azure.take_resource_group_action(
+            MockRmc(), category, resource_group) == action
+
+        # Check that tags match expected
+        if len(expected_tags) > 0:
+            for key, value in expected_tags.items():
+                assert resource_group.tags[key] == value
+
+    check('no_owner', 'owned_by_cloudcleaner',
+          {}, expected_tags={'owner': cloudcleaner.common.CI_OWNER})
+    check('invalid_owner', 'owned_by_cloudcleaner',
+          {'owner': 'foobar'}, expected_tags={'owner': cloudcleaner.common.CI_OWNER,
+                                              'error_message': 'invalid owner was set'})
+    check('error', 'noop', {})
+
+    check('needs_expiration', 'add_expiration', {}, expected_tags={'expiration': '2h'})
+    check('invalid_expiration', 'add_expiration', {'expiration': 'foobar'}, expected_tags={'expiration': '2h'})
+    check('invalid_expiration', 'add_expiration',
+          {'expiration': 'foobar', 'owner': 'test_user', 'creation_time': dump_time(now)},
+          expected_tags={'expiration': '2h'})
+
+    check('needs_creation_time', 'add_creation_time', {},
+          expected_tags={'creation_time': dump_time(now - timedelta(days=30))})
+    check('invalid_creation_time', 'add_creation_time', {'creation_time': 'foobar'},
+          expected_tags={'creation_time': dump_time(now - timedelta(days=30))})
+
+    check('expired', 'deleted', {'owner': 'test_user', 'creation_time': dump_time(now)})
+
+
+def test_advance_states(tmpdir, monkeypatch, mocked_rmc):
+    monkeypatch.setattr(
+        cloudcleaner.azure, 'tag_creation_time',
+        lambda rg: rg.tags.update({'creation_time': dump_time(now)}))
+    with tmpdir.as_cwd():
+        do_test_advance_states(monkeypatch)
+
+
+def do_test_advance_states(monkeypatch):
+    """make a number of resource groups with different tags and step through them
+    """
+    anonymous = _MockResourceGroup({}, name='anonymous')  # should be deleted in 2h
+    invalid_user = _MockResourceGroup({'owner': 'foo'}, name='invalid_user')  # should be deleted in 2h
+    valid_user = _MockResourceGroup({'owner': 'test_user'}, name='valid_user')  # should be deleted in 2h
+    # gone in 2h
+    invalid_expiration = _MockResourceGroup({
+        'expiration': 'next week',
+        'owner': 'test_user',
+        'creation_time': dump_time(now)}, name='invalid_expiration')
+    # will be deleted 12h in
+    ok_group = _MockResourceGroup({
+        'owner': 'test_user',
+        'creation_time': dump_time(now - timedelta(hours=36)),
+        'expiration': '2days'}, name='ok_group')
+    # will be deleted 1h in
+    ci_group = _MockResourceGroup({
+        'owner': cloudcleaner.common.CI_OWNER,
+        'creation_time': dump_time(now - timedelta(hours=3)),
+        'expiration': '4h'}, name='ci_group')
+    # will never expire
+    never_expire = _MockResourceGroup({'expiration': 'never'}, name='never_expire')
+
+    resource_group_pool = [anonymous, invalid_user, valid_user, ok_group, ci_group, invalid_expiration, never_expire]
+
+    expected_states = [
+        (
+            timedelta(minutes=0),
+            {
+                'never_expire': ['never_expire'],
+                'no_owner': ['anonymous', 'never_expire'],
+                'invalid_owner': ['invalid_user'],
+                'needs_creation_time': ['anonymous', 'valid_user', 'invalid_user', 'never_expire'],
+                'needs_expiration': ['anonymous', 'valid_user', 'invalid_user'],
+                'ok': ['ok_group', 'ci_group']
+            },
+            {
+                'owned_by_cloudcleaner': ['anonymous', 'invalid_user', 'never_expire'],
+                'add_expiration': ['anonymous', 'valid_user', 'invalid_user', 'invalid_expiration'],
+                'add_creation_time': ['anonymous', 'valid_user', 'invalid_user', 'never_expire'],
+            },
+        ),
+        (
+            timedelta(hours=1) - cloudcleaner.common.EXPIRE_WARNING_TIME,
+            {
+                'never_expire': ['never_expire'],
+                'ok': ['ok_group', 'anonymous', 'invalid_user',
+                       'valid_user', 'invalid_expiration'],
+                'expire_soon': ['ci_group']
+            },
+            {}
+        ),
+        (
+            timedelta(hours=1),
+            {
+                'never_expire': ['never_expire'],
+                'ok': ['ok_group', 'anonymous', 'invalid_user',
+                       'valid_user', 'invalid_expiration'],
+                'expired': ['ci_group']
+            },
+            {
+                'deleted': ['ci_group']
+            },
+            {}
+        ),
+        (
+            timedelta(hours=2) - cloudcleaner.common.EXPIRE_WARNING_TIME,
+            {
+                'never_expire': ['never_expire'],
+                'ok': ['ok_group'],
+                'expire_soon': ['invalid_expiration', 'valid_user', 'invalid_user', 'anonymous']
+            },
+            {}
+        ),
+        (
+            timedelta(hours=2),
+            {
+                'never_expire': ['never_expire'],
+                'ok': ['ok_group'],
+                'expired': ['invalid_expiration', 'anonymous', 'invalid_user', 'valid_user']
+            },
+            {
+                'deleted': ['anonymous', 'invalid_expiration', 'valid_user', 'invalid_user']
+            },
+            {}
+        ),
+        (
+            timedelta(hours=12) - cloudcleaner.common.EXPIRE_WARNING_TIME,
+            {
+                'never_expire': ['never_expire'],
+                'expire_soon': ['ok_group']
+            },
+            {}
+        ),
+        (
+            timedelta(hours=12),
+            {
+                'never_expire': ['never_expire'],
+                'expired': ['ok_group']
+            },
+            {
+                'deleted': ['ok_group']
+            },
+        ),
+        (
+            timedelta(hours=20),
+            {
+                'never_expire': ['never_expire'],
+            },
+            {}
+        )
+    ]
+
+    # State tracking
+    clock = copy.copy(now)
+    time_passed = timedelta()
+    step_duration = cloudcleaner.common.EXPIRE_WARNING_TIME
+    # step_duration = timedelta(minutes=30)
+
+    mock_rmc = MockRmc(group_list=resource_group_pool)
+    # Make it so do_main is running in the sandbox we've prepared, clock and all.
+    monkeypatch.setattr('cloudcleaner.get_users', lambda: ['test_user'])
+    monkeypatch.setattr('cloudcleaner.get_time', lambda: clock)
+    monkeypatch.setattr(cloudcleaner.azure, 'get_resource_mgmt_client', lambda: mock_rmc)
+    monkeypatch.setattr(cloudcleaner.azure, 'resource_group_to_json', lambda rg, now: rg.name)
+
+    # Make sure the build directory is clean so we only get output from the
+    # current run of do_main
+    assert not os.path.exists('cloudcleaner.html')
+    assert not os.path.exists('report.json')
+
+    expected_state = expected_states.pop(0)
+
+    while True:
+
+        cloudcleaner.main.do_main(['--be-ruthless'])
+
+        report = json.load(open('report.json'))['azure']
+        # Sorted to ensure stable results
+        if time_passed >= expected_state[0]:
+            for k, v in expected_state[1].items():
+                found_groups = report['categorized_resource_groups'][k]
+                expected_groups = expected_state[1][k]
+                assert set(found_groups) == set(expected_groups), 'T={}. {}: found {} but expected {}'.format(
+                    time_passed, k, found_groups, expected_groups)
+            for k, v in expected_state[2].items():
+                found_groups = report['resource_group_actions'][k]
+                expected_groups = v
+                assert set(found_groups) == set(expected_groups), 'T={}. {}: found {} but expected {}'.format(
+                    time_passed, k, found_groups, expected_groups)
+
+            # Now reset for the next state
+            if len(expected_states) == 0:
+                break
+            expected_state = expected_states.pop(0)
+
+        # Make sure the html report exists
+        assert os.path.exists('cloudcleaner.html')
+
+        # Advance in time
+        clock += step_duration
+        time_passed += step_duration
+
+        # Stop after simulating 30 hours.
+        if time_passed >= timedelta(hours=30):
+            break
+
+
+def test_resource_group_to_json(mocked_rmc):
+    assert resource_group_to_json(
+        _MockResourceGroup({}, name='foobar'), now) == {
+            'name': 'foobar',
+            'state': 'Succeeded',
+            'creation_time': 'unset',
+            'expiration': 'unset',
+            'owner': 'unset'}
+    assert resource_group_to_json(
+        _MockResourceGroup({'owner': 'foobar'}, name='baz'), now) == {
+            'name': 'baz',
+            'state': 'Succeeded',
+            'creation_time': 'unset',
+            'expiration': 'unset',
+            'owner': 'foobar'}
+    assert resource_group_to_json(
+        _MockResourceGroup({'expiration': 'never'}, name='abc'), now) == {
+            'name': 'abc',
+            'state': 'Succeeded',
+            'creation_time': 'unset',
+            'owner': 'unset',
+            'expiration': 'never'}
+    assert resource_group_to_json(
+        _MockResourceGroup({'creation_time': dump_time(now)}, name='xyz'), now) == {
+            'name': 'xyz',
+            'creation_time': dump_time(now),
+            'state': 'Succeeded',
+            'owner': 'unset',
+            'expiration': 'unset',
+            'uptime': '0m'}

--- a/cloudcleaner/test_common.py
+++ b/cloudcleaner/test_common.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta, timezone
+
+import cloudcleaner
+
+now = datetime(2016, 1, 8, 1, 20, 30, 14, timezone.utc)
+
+
+def test_delta_to_str():
+    """Test converting a timedelta to a string notation for it."""
+    def check(delta_str, delta):
+        assert cloudcleaner.common.delta_to_str(delta) == delta_str
+
+    check('0m', timedelta())
+    # Round up to one minute for seconds less than a minute
+    check('1m', timedelta(seconds=10))
+    check('1m', timedelta(minutes=1))
+    check('2m', timedelta(minutes=1, seconds=5))
+    check('1h', timedelta(minutes=60))
+    check('1h5m', timedelta(minutes=65))
+    check('1d', timedelta(days=1))
+    check('1d2m', timedelta(days=1, minutes=2))
+    check('1d23h59m', timedelta(days=1, hours=23, minutes=59))
+    check('2w', timedelta(weeks=2))
+    check('2w1m', timedelta(weeks=2, seconds=10))
+    check('-2w1m', -timedelta(weeks=2, seconds=10))
+    check('-1d23h59m', -timedelta(days=1, hours=23, minutes=59))
+
+
+def test_parse_delta():
+    """Test parsing a timedelta string produces the expected timedelta."""
+    parse = cloudcleaner.common.parse_delta
+    assert parse('') == timedelta()
+    assert parse('8hours') == timedelta(hours=8)
+    assert parse('1m') == timedelta(minutes=1)
+    assert parse(' 23 h ') == timedelta(hours=23)
+    assert parse('2 d ') == timedelta(days=2)
+    assert parse(' 987 w') == timedelta(weeks=987)
+    assert parse('5h2m') == timedelta(hours=5, minutes=2)
+    assert parse('1w2d13m') == timedelta(weeks=1, days=2, minutes=13)
+    assert parse('13m1w') == timedelta(weeks=1, minutes=13)
+    assert parse("5days2hours") == timedelta(days=5, hours=2)
+    assert parse("24hours15minutes") == timedelta(hours=24, minutes=15)
+    assert parse("5weeks3hours") == timedelta(weeks=5, hours=3)

--- a/cloudcleaner/test_docker.py
+++ b/cloudcleaner/test_docker.py
@@ -1,0 +1,13 @@
+"""Test that the mesosphere/cloudcleaner docker seems to work."""
+import subprocess
+
+
+def test_docker():
+    """Check that the container can run."""
+    subproc = subprocess.Popen(
+        ["docker", "run", "mesosphere/cloudcleaner"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    stdout, stderr = subproc.communicate()
+
+    assert stderr.decode() == "" and stdout.decode().startswith("ERROR:") and subproc.returncode == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,21 @@
+aiodns
+aiohttp
+aiohttp-debugtoolbar
+aiomysql
+azure-common
 azure-storage
 azure-mgmt-network
 azure-mgmt-resource
+azure-monitor
 boto3
 botocore
 cerberus
 docopt
 git+https://github.com/mesosphere/dcos-test-utils@remove_dcos_launch
 google-api-python-client
+jinja2
+msrest==0.4.4
+msrestazure==0.4.7
 oauth2client==3.0.0
 pyinstaller==3.2
 py
@@ -14,4 +23,5 @@ pytest
 pyyaml
 requests==2.14.1
 retrying
+slacker
 tox

--- a/setup.py
+++ b/setup.py
@@ -14,23 +14,33 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
     ],
-    packages=['dcos_launch'],
+    packages=['dcos_launch', 'cloudcleaner'],
     install_requires=[
+        'aiodns',
+        'aiohttp',
+        'aiohttp-debugtoolbar',
+        'aiomysql',
+        'azure-common',
         'azure-storage',
         'azure-mgmt-network',
         'azure-mgmt-resource',
+        'azure-monitor',
         'boto3',
         'botocore',
         'cerberus',
         'docopt',
         'google-api-python-client',
+        'jinja2',
+        'msrest==0.4.4',
+        'msrestazure==0.4.7',
         'oauth2client==3.0.0',
         'pyinstaller==3.2',
         'py',
         'pytest',
         'pyyaml',
         'requests==2.14.1',
-        'retrying'],
+        'retrying',
+        'slacker'],
     entry_points={
         'console_scripts': [
             'dcos-launch=dcos_launch.cli:main',
@@ -40,6 +50,7 @@ setup(
         'https://github.com/mesosphere/dcos-test-utils@remove_dcos_launch'
     ],
     package_data={
+        'cloudcleaner': ['report.html.jinja'],
         'dcos_launch': [
             'sample_configs/*.yaml'
             'ip-detect/aws.sh',

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,14 @@ envlist = py35-{syntax,unit-tests,build-binary}
 deps = flake8-import-order
 max-line-length = 120
 exclude = .git,.tox,__pycache__,lib,bin,include
-application-import-names = dcos_launch
+application-import-names = dcos_launch,cloudcleaner
 import-order-style = smarkets
 
 [pytest]
 addopts = -rs -vv
 testpaths =
   dcos_launch
+  cloudcleaner
 
 [testenv]
 deps =


### PR DESCRIPTION
Removed the notifications system in cloudcleaner (includes Slack and Cassandra usage) and moving the repo as a subfolder here in dcos-test-utils. You can see all the changes versus cloudcleaner's master branch here: https://github.com/mesosphere/cloudcleaner/compare/no_notifs?expand=1

Reasoning for moving cloudcleaner in dcos-test-utils:

cloudcleaner uses the APIs of azure, AWS (and GCE in the future). All calls to these APIs should be in one place (dcos-test-utils/dcos_test_utils) and not duplicated/separated cloudcleaner
cloudcleaner is used to clean up clusters created by dcos-launch, so it makes sense these two live in the same repo.
Reasoning for removing notifications:
The notifications system is complex, represents a considerable amount of code and uses Cassandra and Slack in its process. Consequently, the code base complexity and maintenance burden it brings outweigh its value/usefulness.
Furthermore, the deployment of many dcos-launch clusters is done through CI jobs. In those cases, it's unlikely that users would want to receive Slack notifications about expiring clusters that were deployed and tagged automatically. 

ticket: https://jira.mesosphere.com/browse/DCOS_OSS-1330