### PR TITLE
Add option to configure rollback in AWS

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -30,7 +30,8 @@ class DcosCloudformationLauncher(dcos_launch.util.AbstractLauncher):
                 self.config['deployment_name'],
                 self.config['template_parameters'],
                 template_url=self.config.get('template_url'),
-                template_body=self.config.get('template_body'))
+                template_body=self.config.get('template_body'),
+                disable_rollback=self.config['disable_rollback'])
         except Exception as ex:
             self.delete_temp_resources(temp_resources)
             raise dcos_launch.util.LauncherError('ProviderError', None) from ex

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -107,7 +107,11 @@ def get_validated_config(config_path: str) -> dict:
             'aws_region': {
                 'type': 'string',
                 'required': True,
-                'default_setter': lambda doc: dcos_launch.util.set_from_env('AWS_REGION')}})
+                'default_setter': lambda doc: dcos_launch.util.set_from_env('AWS_REGION')},
+            'disable_rollback': {
+                'type': 'boolean',
+                'required': False,
+                'default': False}})
         if provider == 'onprem':
             validator.schema.update(AWS_ONPREM_SCHEMA)
     elif platform == 'gce':

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -122,7 +122,14 @@ class BotoWrapper():
         log.info('Deleting KeyPair: {}'.format(key_name))
         self.resource('ec2').KeyPair(key_name).delete()
 
-    def create_stack(self, name, parameters, template_url=None, template_body=None, deploy_timeout=60):
+    def create_stack(
+            self,
+            name: str,
+            parameters: dict,
+            template_url: str=None,
+            template_body: str=None,
+            deploy_timeout: int=60,
+            disable_rollback: bool=False):
         """Pulls template and checks user params versus temlate params.
         Does simple casting of strings or numbers
         Starts stack creation if validation is successful
@@ -130,7 +137,7 @@ class BotoWrapper():
         log.info('Requesting AWS CloudFormation: {}'.format(name))
         args = {
             'StackName': name,
-            'DisableRollback': True,
+            'DisableRollback': disable_rollback,
             'TimeoutInMinutes': deploy_timeout,
             'Capabilities': ['CAPABILITY_IAM'],
             # this python API only accepts data in string format; cast as string here

--- a/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
+++ b/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
@@ -4,6 +4,7 @@ deployment_name: This-is-a-test-stack
 template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
+disable_rollback: true
 template_parameters:
     KeyName: foo_key
     AdminLocation: 0.0.0.0/0

--- a/dcos_launch/sample_configs/aws-onprem.yaml
+++ b/dcos_launch/sample_configs/aws-onprem.yaml
@@ -8,6 +8,7 @@ aws_region: us-west-2
 aws_key_name: default
 os_name: cent-os-7
 instance_type: t2.micro
+disable_rollback: false
 dcos_config:
     cluster_name: My Awesome DC/OS
     resolvers:


### PR DESCRIPTION
Support for automatically cleaning up clusters that failed to launch by default