### PR TITLE
tox modifs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ commands = flake8 --verbose
 
 [testenv:py35-unit-tests]
 passenv = TEAMCITY_VERSION
-commands = py.test {posargs}
+commands = py.test --tb=long {posargs}
 
 [testenv:py35-build-binary]
 passenv = TEAMCITY_VERSION
@@ -51,44 +51,3 @@ passenv =
 commands =
   dcos-launch {posargs}
 
-[testenv:py35-upgrade-test]
-passenv =
-  AWS_ACCESS_KEY_ID
-  AWS_SECRET_ACCESS_KEY
-  AWS_REGION
-  TEST_UPGRADE_INSTALLER_URL
-  TEST_UPGRADE_USE_CHECKS
-  TEST_UPGRADE_CONFIG_PATH
-  TEST_UPGRADE_ENTERPRISE
-  TEST_LAUNCH_CONFIG_PATH
-  TEST_CREATE_CLUSTER
-  TEST_CLUSTER_INFO_PATH
-  DCOS_LOGIN_UNAME
-  DCOS_LOGIN_PW
-  TEAMCITY_VERSION
-commands =
-  py.test {posargs} advanced_tests/test_upgrade.py
-
-[testenv:py35-failure-test]
-passenv =
-  AWS_ACCESS_KEY_ID
-  AWS_SECRET_ACCESS_KEY
-  AWS_REGION
-  TEST_LAUNCH_CONFIG_PATH
-  TEST_CREATE_CLUSTER
-  TEST_CLUSTER_INFO_PATH
-  TEAMCITY_VERSION
-commands =
-  py.test {posargs} advanced_tests/test_aws_cf_failure.py
-
-[testenv:py35-installer-test]
-passenv =
-  AWS_ACCESS_KEY_ID
-  AWS_SECRET_ACCESS_KEY
-  AWS_REGION
-  TEST_LAUNCH_CONFIG_PATH
-  TEST_CREATE_CLUSTER
-  TEST_CLUSTER_INFO_PATH
-  TEST_INSTALL_PREREQS
-  TEAMCITY_VERSION
-commands = py.test {posargs} advanced_tests/test_installer_cli.py


### PR DESCRIPTION
Stack trace wasn't helpful enough so added: --tb=long
Sections relating to advanced tests removed because advanced tests are in a separate repo now