### PR TITLE
delete cluster_info.json when the corresponding cluster is deleted

### DIFF
--- a/dcos_launch/cli.py
+++ b/dcos_launch/cli.py
@@ -115,6 +115,7 @@ def do_main(args):
 
     if args['delete']:
         launcher.delete()
+        os.remove(args['--info-path'])
         return 0
 
 


### PR DESCRIPTION
no use for the old cluster_info.json when its corresponding cluster doesn't exist ?