### PR TITLE
add monitor client to azure wrapper

### DIFF
--- a/dcos_launch/platforms/arm.py
+++ b/dcos_launch/platforms/arm.py
@@ -18,6 +18,7 @@ from azure.mgmt.resource.resources.v2016_02_01 import ResourceManagementClient
 from azure.mgmt.resource.resources.v2016_02_01.models import (DeploymentMode,
                                                               DeploymentProperties,
                                                               ResourceGroup)
+from azure.monitor import MonitorClient
 
 from dcos_test_utils.helpers import Host
 
@@ -70,6 +71,7 @@ class AzureWrapper:
             tenant=tenant_id)
         self.rmc = ResourceManagementClient(self.credentials, subscription_id)
         self.nmc = NetworkManagementClient(self.credentials, subscription_id)
+        self.mc = MonitorClient(self.credentials, subscription_id)
         # location is included to keep a similar model as dcos_launch.platforms.aws.BotoWrapper
         self.location = location
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 azure-storage
 azure-mgmt-network
 azure-mgmt-resource
+azure-monitor
 boto3
 botocore
 cerberus

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'azure-storage',
         'azure-mgmt-network',
         'azure-mgmt-resource',
+        'azure-monitor',
         'boto3',
         'botocore',
         'cerberus',


### PR DESCRIPTION
Monitor client was removed from dcos-launch-control but never added in dcos-launch. It's needed for the tag_creation_time function of Azure