### PR TITLE
Gce polling

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -246,7 +246,7 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         # not required because machine image can be set directly
         'required': False,
-        'default': 'cent-os-7-dcos-prereqs',
+        'default': 'cent-os-7',
         'allowed': list(dcos_launch.platforms.aws.OS_SSH_INFO.keys())},
     'instance_ami': {
         'type': 'string',

--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -178,7 +178,7 @@ class GceWrapper:
 
     @catch_http_exceptions
     def get_deployments(self):
-        request = self.deployment_manager.list(project=self.project_id)
+        request = self.deployment_manager.deployments().list(project=self.project_id)
         while request is not None:
             response = request.execute()
             for deployment_info in response['deployments']:

--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -227,7 +227,7 @@ class Deployment:
         else:
             raise Exception('Deployment failed with response: ' + str(response))
 
-    @retry(wait_fixed=2000, retry_on_result=_check_status, retry_on_exception=lambda _: False)
+    @retry(wait_fixed=60 * 1000, retry_on_result=_check_status, retry_on_exception=lambda _: False)
     def wait_for_completion(self) -> dict:
         return self.get_info()
 

--- a/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
+++ b/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
@@ -10,4 +10,3 @@ template_parameters:
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 2
     SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge

--- a/dcos_launch/sample_configs/aws-cf-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-cf-with-helper.yaml
@@ -1,13 +1,12 @@
 ---
 launch_config_version: 1
-deployment_name: This-is-a-test-stack
+deployment_name: aws-cf-test
 template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
 key_helper: true
 template_parameters:
     AdminLocation: 0.0.0.0/0
-    PublicSlaveInstanceCount: 2
-    SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge
+    PublicSlaveInstanceCount: 1
+    SlaveInstanceCount: 2
 ssh_user: core

--- a/dcos_launch/sample_configs/aws-cf.yaml
+++ b/dcos_launch/sample_configs/aws-cf.yaml
@@ -9,6 +9,5 @@ template_parameters:
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 2
     SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge
 ssh_user: core
 ssh_private_key_filename: /tmp/aawpei3

--- a/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
@@ -1,12 +1,12 @@
 ---
 launch_config_version: 1
-deployment_name: dcos-onprem-with-new-stack
+deployment_name: aws-onprem-test1
 installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
 platform: aws
 provider: onprem
 aws_region: us-west-2
 os_name: cent-os-7
-instance_type: t2.micro
+instance_type: m4.xlarge
 dcos_config:
     cluster_name: My Awesome DC/OS
     resolvers:
@@ -14,8 +14,8 @@ dcos_config:
         - 8.8.8.8
     dns_search: mesos
     master_discovery: static
-    ip_detect_filename: ip-detect.sh
-num_masters: 3
+num_masters: 1
 num_private_agents: 2
 num_public_agents: 1
 key_helper: true
+ssh_user: centos

--- a/dcos_launch/sample_configs/aws-onprem.yaml
+++ b/dcos_launch/sample_configs/aws-onprem.yaml
@@ -7,7 +7,7 @@ provider: onprem
 aws_region: us-west-2
 aws_key_name: default
 os_name: cent-os-7
-instance_type: t2.micro
+instance_type: m4.xlarge
 disable_rollback: false
 dcos_config:
     cluster_name: My Awesome DC/OS
@@ -16,7 +16,6 @@ dcos_config:
         - 8.8.8.8
     dns_search: mesos
     master_discovery: static
-    ip_detect_filename: ip-detect.sh
 num_masters: 3
 num_private_agents: 2
 num_public_agents: 1

--- a/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
@@ -1,6 +1,6 @@
 ---
 launch_config_version: 1
-deployment_name: dcos-onprem-gce-with-helper
+deployment_name: gce-on-prem-test1
 installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
 platform: gce
 provider: onprem

--- a/dcos_launch/sample_configs/gce-onprem.yaml
+++ b/dcos_launch/sample_configs/gce-onprem.yaml
@@ -1,6 +1,6 @@
 ---
 launch_config_version: 1
-deployment_name: dcos-onprem-gce
+deployment_name: dcos-onprem-gce-2
 installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
 platform: gce
 provider: onprem


### PR DESCRIPTION
1. GCE polling was too short and caused ./dcos-launch wait to crash when attempting to get host ips too quickly after the cluster was up

2. Several of the sample configs didn't work. e.g. SlaveInstanceType is not in the template