### PR TITLE
can specify os_name or source_image for onprem on GCE

### DIFF
--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -26,15 +26,6 @@ OS_IMAGE_FAMILIES = {
     'coreos': 'coreos-stable',
 }
 
-# used in the gce sourceImage link (instance template field)
-IMAGE_PROJECTS = {
-    'centos-7': 'centos-cloud',
-    'rhel-7': 'rhel-cloud',
-    'ubuntu-1604-lts': 'ubuntu-os-cloud',
-    'coreos-stable': 'coreos-cloud',
-    'debian-8': 'debian-cloud'
-}
-
 # template for an "instance template" resource to be used in a managed instance group
 INSTANCE_TEMPLATE = """
 type: compute.v1.instanceTemplate
@@ -54,7 +45,7 @@ properties:
       initializeParams:
         diskSizeGb: {diskSizeGb}
         diskType: {diskType}
-        sourceImage: projects/{imageProject}/global/images/family/{sourceImage}
+        sourceImage: projects/{imageProject}/global/images/{sourceImage}
     networkInterfaces:
     - network: global/networks/{network}
       # Access Config required to give the instance a public IP address

--- a/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
@@ -4,7 +4,7 @@ deployment_name: dcos-onprem-gce-with-helper
 installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
 platform: gce
 provider: onprem
-os_name: coreos
+source_image: coreos-stable-1465-6-0-v20170817
 dcos_config:
     cluster_name: My Awesome DC/OS
     resolvers:


### PR DESCRIPTION
1. With the previous GCE instance template, specifying a source image in the dcos-launch config did not work. Only the os_name parameter worked with that format "/family/".

2. This also means that the previous method for finding the gce image project would no longer work because it would find it through the os_name, so I implemented another one that works both for os_name and source_image (deduce_image_project function).

3. The rest of changes are import formats