### PR TITLE
increase gce polling time, change sample configs, fix aws region bug

### DIFF
--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -123,10 +123,11 @@ class BotoWrapper:
         return key['KeyMaterial']
 
     @retry_boto_rate_limits
-    def get_service_resources(self, service, resource):
+    def get_service_resources(self, service, resource_name):
         """Return resources and boto wrapper in every region for the given boto3 service and resource type."""
         for region in aws_region_names:
-            for resource in getattr(self.resource(service, region['id']), resource).all():
+            self.region = region['id']
+            for resource in getattr(self.resource(service, region['id']), resource_name).all():
                 yield resource
 
     @retry_boto_rate_limits

--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -218,7 +218,7 @@ class Deployment:
         else:
             raise Exception('Deployment failed with response: ' + str(response))
 
-    @retry(wait_fixed=2000, retry_on_result=_check_status, retry_on_exception=lambda _: False)
+    @retry(wait_fixed=60 * 1000, retry_on_result=_check_status, retry_on_exception=lambda _: False)
     def wait_for_completion(self) -> dict:
         return self.get_info()
 

--- a/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
+++ b/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
@@ -10,4 +10,3 @@ template_parameters:
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 2
     SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge

--- a/dcos_launch/sample_configs/aws-cf-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-cf-with-helper.yaml
@@ -1,6 +1,6 @@
 ---
 launch_config_version: 1
-deployment_name: This-is-a-test-stack
+deployment_name: aws-cf-with-helper-test
 template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
@@ -9,5 +9,4 @@ template_parameters:
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 2
     SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge
 ssh_user: core

--- a/dcos_launch/sample_configs/aws-cf.yaml
+++ b/dcos_launch/sample_configs/aws-cf.yaml
@@ -9,6 +9,5 @@ template_parameters:
     AdminLocation: 0.0.0.0/0
     PublicSlaveInstanceCount: 2
     SlaveInstanceCount: 1
-    PublicSlaveInstanceType: m4.xlarge
 ssh_user: core
 ssh_private_key_filename: /tmp/aawpei3

--- a/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
@@ -6,16 +6,16 @@ platform: aws
 provider: onprem
 aws_region: us-west-2
 os_name: cent-os-7
-instance_type: t2.micro
+instance_type: m4.xlarge
 dcos_config:
-    cluster_name: My Awesome DC/OS
-    resolvers:
-        - 8.8.4.4
-        - 8.8.8.8
-    dns_search: mesos
-    master_discovery: static
-    ip_detect_filename: ip-detect.sh
-num_masters: 3
-num_private_agents: 2
+  cluster_name: My Awesome DC/OS
+  resolvers:
+    - 8.8.4.4
+    - 8.8.8.8
+  dns_search: mesos
+  master_discovery: static
+num_masters: 1
+num_private_agents: 1
 num_public_agents: 1
+ssh_user: centos
 key_helper: true

--- a/dcos_launch/sample_configs/aws-onprem.yaml
+++ b/dcos_launch/sample_configs/aws-onprem.yaml
@@ -7,7 +7,7 @@ provider: onprem
 aws_region: us-west-2
 aws_key_name: default
 os_name: cent-os-7
-instance_type: t2.micro
+instance_type: m4.xlarge
 disable_rollback: false
 dcos_config:
     cluster_name: My Awesome DC/OS
@@ -16,7 +16,6 @@ dcos_config:
         - 8.8.8.8
     dns_search: mesos
     master_discovery: static
-    ip_detect_filename: ip-detect.sh
 num_masters: 3
 num_private_agents: 2
 num_public_agents: 1

--- a/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
@@ -1,6 +1,6 @@
 ---
 launch_config_version: 1
-deployment_name: dcos-onprem-gce-with-helper
+deployment_name: dcos-onprem-gce-with-helper-test
 installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
 platform: gce
 provider: onprem
@@ -12,8 +12,10 @@ dcos_config:
         - 8.8.8.8
     dns_search: mesos
     master_discovery: static
+    exhibitor_storage_backend: zookeeper
+    exhibitor_zk_path: /exhibitor
 num_masters: 1
-num_private_agents: 2
+num_private_agents: 1
 num_public_agents: 1
 key_helper: true
 ssh_user: dcos


### PR DESCRIPTION
1. gce "wait" polling time was much shorter than for other platforms. The polling time needs to be consistent accross platforms so that dcos-launch-control knows how long it must wait to tag a new cluster
2. several sample configs didn't work
3. last PR broke dcos-launch-control (region is None bug when getting resources)