### PR TITLE
add disable_updates flag for CoreOS

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -311,4 +311,8 @@ GCE_ONPREM_SCHEMA = {
     'disk_type': {
         'type': 'string',
         'required': False,
-        'default': 'pd-ssd'}}
+        'default': 'pd-ssd'},
+    'disable_updates': {
+        'type': 'boolean',
+        'required': False,
+        'default': False}}

--- a/dcos_launch/gce.py
+++ b/dcos_launch/gce.py
@@ -57,7 +57,8 @@ class BareClusterLauncher(util.AbstractLauncher):
             self.config['machine_type'],
             self.config['image_project'],
             self.config['ssh_user'],
-            self.config['ssh_public_key'])
+            self.config['ssh_public_key'],
+            self.config['disable_updates'])
         return self.config
 
     def key_helper(self):

--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -99,6 +99,31 @@ properties:
   - IPProtocol: sctp
 """
 
+# Used to disable automatic updates on CoreOS
+IGNITION_CONFIG = """
+{
+    "ignition": {
+        "version": "2.0.0",
+        "config": {}
+    },
+    "storage": {},
+    "systemd": {
+        "units": [
+            {
+                "name": "update-engine.service",
+                "mask": true
+            },
+            {
+                "name": "locksmithd.service",
+                "mask": true
+            }
+        ]
+    },
+    "networkd": {},
+    "passwd": {}
+}
+"""
+
 
 # Function decorator that adds detail to potential googleapiclient.errors.HttpError exceptions with code 404 or 409
 def catch_http_exceptions(f):
@@ -289,7 +314,8 @@ class BareClusterDeployment(Deployment):
             machine_type: str,
             image_project: str,
             ssh_user: str,
-            ssh_public_key: str):
+            ssh_public_key: str,
+            disable_updates: bool):
         template_name = name + '-template'
         network_name = name + '-network'
         firewall_name = name + '-norules'
@@ -325,6 +351,14 @@ class BareClusterDeployment(Deployment):
                           yaml.load(instance_group_resource),
                           yaml.load(firewall_resource)]
         }
+
+        if disable_updates and image_project == 'coreos-cloud':
+            user_data = {
+                'key': 'user-data',
+                'value': IGNITION_CONFIG
+            }
+            deployment_config['resources'][1]['properties']['properties']['metadata']['items'].append(user_data)
+
         gce_wrapper.create_deployment(name, deployment_config)
         return deployment
 

--- a/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/gce-onprem-with-helper.yaml
@@ -20,3 +20,4 @@ num_public_agents: 1
 key_helper: true
 ssh_user: dcos
 gce_zone: us-west1-a
+disable_updates: True


### PR DESCRIPTION
Automatic updates on CoreOS are causing cluster provisioning failures on GCE because they cause the VMs to reboot.