### PR TITLE
override fault_domain_scripts_contents

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -234,7 +234,10 @@ ONPREM_DEPLOY_COMMON_SCHEMA = {
             # currently, these values cannot be set by a user, only by the launch process
             'master_list': {'readonly': True},
             'agent_list': {'readonly': True},
-            'public_agent_list': {'readonly': True}}}}
+            'public_agent_list': {'readonly': True},
+            'fault_domain_script_filename': {
+                'coerce': 'expand_local_path',
+                'excludes': 'fault_domain_script_contents'}}}}
 
 
 AWS_ONPREM_SCHEMA = {

--- a/dcos_launch/fault-domain-detect/aws.sh
+++ b/dcos_launch/fault-domain-detect/aws.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -o nounset -o errexit
+
+# Get COREOS COREOS_PRIVATE_IPV4
+if [ -e /etc/environment ]
+then
+  set -o allexport
+  source /etc/environment
+  set +o allexport
+fi
+
+METADATA="$(curl http://169.254.169.254/latest/dynamic/instance-identity/document 2>/dev/null)"
+REGION=$(echo $METADATA | grep -Po "\"region\"\s+:\s+\"(.*?)\"" | cut -f2 -d:)
+ZONE=$(echo $METADATA | grep -Po "\"availabilityZone\"\s+:\s+\"(.*?)\"" | cut -f2 -d:)
+
+echo "{\"fault_domain\":{\"region\":{\"name\": $REGION},\"zone\":{\"name\": $ZONE}}}"

--- a/dcos_launch/fault-domain-detect/gce.sh
+++ b/dcos_launch/fault-domain-detect/gce.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -o nounset -o errexit
+
+# Get COREOS COREOS_PRIVATE_IPV4
+if [ -e /etc/environment ]
+then
+  set -o allexport
+  source /etc/environment
+  set +o allexport
+fi
+
+BODY=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone 2>/dev/null)
+
+ZONE=$(echo "$BODY" | sed 's@^projects/.*/zones/\(.*\)$@\1@')
+REGION=$(echo "$ZONE" | sed 's@\(.*-.*\)-.*@\1@')
+
+echo "{\"fault_domain\":{\"region\":{\"name\": \"$REGION\"},\"zone\":{\"name\": \"$ZONE\"}}}"

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -67,7 +67,8 @@ class OnpremLauncher(dcos_launch.util.AbstractLauncher):
         if 'ssh_user' not in onprem_config:
             onprem_config['ssh_user'] = self.config['ssh_user']
         # check if the user provided any filenames and convert them into content
-        for key_name in ('ip_detect_filename', 'ip_detect_public_filename'):
+        for key_name in ('ip_detect_filename', 'ip_detect_public_filename',
+                         'fault_domain_script_filename'):
             if key_name not in onprem_config:
                 continue
             new_key_name = key_name.replace('_filename', '_contents')

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -85,6 +85,9 @@ class OnpremLauncher(dcos_launch.util.AbstractLauncher):
             # despite being almost identical aws_public.sh will crash the installer if not safely dumped
             onprem_config['ip_detect_public_contents'] = yaml.dump(pkg_resources.resource_string(
                 'dcos_launch', 'ip-detect/{}_public.sh'.format(self.config['platform'])).decode())
+        if 'fault_domain_detect_contents' not in onprem_config:
+            onprem_config['fault_domain_detect_contents'] = yaml.dump(pkg_resources.resource_string(
+                'dcos_launch', 'fault-domain-detect/{}.sh'.format(self.config['platform'])).decode())
         # For no good reason the installer uses 'ip_detect_script' instead of 'ip_detect_contents'
         onprem_config['ip_detect_script'] = onprem_config['ip_detect_contents']
         del onprem_config['ip_detect_contents']

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,9 @@ setup(
             'ip-detect/gce.sh',
             'ip-detect/gce_public.sh',
             'templates/vpc-cluster-template.json',
-            'templates/vpc-ebs-only-cluster-template.json'
+            'templates/vpc-ebs-only-cluster-template.json',
+            'fault-domain-detect/aws.sh',
+            'fault-domain-detect/gce.sh'
         ],
     }
 )


### PR DESCRIPTION
make dcos-launch to pass a fault domain script, similar to ip-detect.

introducing a new config option for fault domain
https://github.com/dcos/dcos/pull/1874