### PR TITLE
add the security field to the config validator

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -258,6 +258,10 @@ AWS_ONPREM_SCHEMA = {
     'instance_type': {
         'type': 'string',
         'required': True},
+    'security': {
+        'type': 'string',
+        'required': False,
+        'allowed': ['permissive', 'strict', 'disabled']},
     'admin_location': {
         'type': 'string',
         'required': True,


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-19086
Probably should add other missing fields too.

To-do
- only allow this if it is an enterprise cluster
- tests