### PR TITLE
Use stack_name for consistent handling

### DIFF
--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -479,7 +479,7 @@ class DcosZenCfStack(CfStack):
                   self.public_agent_stack]:
             try:
                 s.delete()
-            except:
+            except Exception:
                 log.exception('Delete encountered an error!')
         super().delete()
 


### PR DESCRIPTION
stack_id was originally used for the extremely rare case
of inspecing deleted clusters. This unintentionally caused
deletion to silently break due to bugs or improper usage
of boto3