### PR TITLE
Allow a separate AMI for Bootstrap host

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -147,7 +147,7 @@ class BareClusterLauncher(DcosCloudformationLauncher):
             'AmiCode': self.config['instance_ami'],
             # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
             # intended to be updated to be configured properly as an EC2 instance later
-            'BootstrapInstanceType': self.config['bootsrap_instance_type'],
+            'BootstrapInstanceType': self.config['bootstrap_instance_type'],
             'BootstrapAmiCode': self.config['bootstrap_ami']
         }
         if not self.config['key_helper']:

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -144,11 +144,12 @@ class BareClusterLauncher(DcosCloudformationLauncher):
             'ClusterSize': (self.config['num_masters'] + self.config['num_public_agents'] +
                             self.config['num_private_agents']),
             'InstanceType': self.config['instance_type'],
-            'AmiCode': self.config['instance_ami']},
+            'AmiCode': self.config['instance_ami'],
             # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
             # intended to be updated to be configured properly as an EC2 instance later
             'BootstrapInstanceType': self.config['boostrap_instance_type'],
             'BootstrapAmiCode': self.config['bootstrap_ami']
+        }
         if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']
         self.config.update({

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -147,7 +147,7 @@ class BareClusterLauncher(DcosCloudformationLauncher):
             'AmiCode': self.config['instance_ami'],
             # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
             # intended to be updated to be configured properly as an EC2 instance later
-            'BootstrapInstanceType': self.config['boostrap_instance_type'],
+            'BootstrapInstanceType': self.config['bootsrap_instance_type'],
             'BootstrapAmiCode': self.config['bootstrap_ami']
         }
         if not self.config['key_helper']:

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -133,7 +133,7 @@ class DcosCloudformationLauncher(dcos_launch.util.AbstractLauncher):
             raise dcos_launch.util.LauncherError('StackNotFound', None) from ex
 
 
-class BareClusterLauncher(DcosCloudformationLauncher):
+class BareClusterLauncher(DcosCloudformationLauncher, dcos_launch.util.AbstractOnpremClusterLauncher):
     """ Launches a homogeneous cluster of plain AMIs intended for onprem DC/OS
     """
     def create(self):
@@ -157,8 +157,11 @@ class BareClusterLauncher(DcosCloudformationLauncher):
             'template_parameters': template_parameters})
         return super().create()
 
-    def get_hosts(self):
-        return self.stack.get_host_ips()
+    def get_cluster_hosts(self):
+        return self.stack.get_cluster_host_ips()
+
+    def get_bootstrap_host(self):
+        return self.stack.get_bootstrap_ip()
 
     def test(self, args, env, test_host=None, test_port=22):
         raise NotImplementedError('Bare clusters cannot be tested!')

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -148,7 +148,7 @@ class BareClusterLauncher(DcosCloudformationLauncher):
             # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
             # intended to be updated to be configured properly as an EC2 instance later
             'BootstrapInstanceType': self.config['bootstrap_instance_type'],
-            'BootstrapAmiCode': self.config['bootstrap_ami']
+            'BootstrapAmiCode': self.config['bootstrap_instance_ami']
         }
         if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -141,11 +141,14 @@ class BareClusterLauncher(DcosCloudformationLauncher):
         """
         template_parameters = {
             'AllowAccessFrom': self.config['admin_location'],
-            # cluster size is +1 for the bootstrap node
-            'ClusterSize': (1 + self.config['num_masters'] + self.config['num_public_agents'] +
+            'ClusterSize': (self.config['num_masters'] + self.config['num_public_agents'] +
                             self.config['num_private_agents']),
             'InstanceType': self.config['instance_type'],
-            'AmiCode': self.config['instance_ami']}
+            'AmiCode': self.config['instance_ami']},
+            # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
+            # intended to be updated to be configured properly as an EC2 instance later
+            'BootstrapInstanceType': self.config['boostrap_instance_type'],
+            'BootstrapAmiCode': self.config['bootstrap_ami']
         if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']
         self.config.update({

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -269,6 +269,14 @@ AWS_ONPREM_SCHEMA = {
     'instance_type': {
         'type': 'string',
         'required': True},
+    'bootstrap_instance_ami': {
+        'type': 'string',
+        'required': True,
+        'default_setter': lambda doc: aws.OS_AMIS[doc['os_name']][doc['aws_region']]},
+    'bootstrap_instance_type': {
+        'type': 'string',
+        'required': True,
+        'default': 'm4.xlarge'},
     'admin_location': {
         'type': 'string',
         'required': True,

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -266,7 +266,7 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         'required': False,
         # bootstrap node requires docker to be installed
-        'default_setter': 'cent-os-7-dcos-prereqs',
+        'default': 'cent-os-7-dcos-prereqs',
         'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -265,7 +265,7 @@ AWS_ONPREM_SCHEMA = {
     'bootstrap_os_name': {
         'type': 'string',
         'required': False,
-        'default': 'cent-os-7-dcos-prereqs',
+        'default_setter': lambda doc: doc.get('os_name') or 'cent-os-7-dcos-prereqs',
         'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -265,7 +265,8 @@ AWS_ONPREM_SCHEMA = {
     'bootstrap_os_name': {
         'type': 'string',
         'required': False,
-        'default_setter': lambda doc: doc.get('os_name') or 'cent-os-7-dcos-prereqs',
+        # bootstrap node requires docker to be installed
+        'default_setter': 'cent-os-7-dcos-prereqs',
         'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -262,6 +262,11 @@ AWS_ONPREM_SCHEMA = {
         'required': False,
         'default': 'cent-os-7-dcos-prereqs',
         'allowed': list(aws.OS_SSH_INFO.keys())},
+    'bootstrap_os_name': {
+        'type': 'string',
+        'required': False,
+        'default': 'cent-os-7-dcos-prereqs',
+        'allowed': list(aws.OS_SSH_INFO.keys())},
     'instance_ami': {
         'type': 'string',
         'required': True,
@@ -272,7 +277,7 @@ AWS_ONPREM_SCHEMA = {
     'bootstrap_instance_ami': {
         'type': 'string',
         'required': True,
-        'default_setter': lambda doc: aws.OS_AMIS[doc['os_name']][doc['aws_region']]},
+        'default_setter': lambda doc: aws.OS_AMIS[doc['bootstrap_os_name']][doc['aws_region']]},
     'bootstrap_instance_type': {
         'type': 'string',
         'required': True,

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -261,12 +261,12 @@ AWS_ONPREM_SCHEMA = {
         # not required because machine image can be set directly
         'required': False,
         'default': 'cent-os-7-dcos-prereqs',
-        'allowed': list(aws.OS_SSH_INFO.keys())},
+        'allowed': list(aws.OS_AMIS.keys())},
     'bootstrap_os_name': {
         'type': 'string',
         'required': False,
         'default': 'cent-os-7-dcos-prereqs',
-        'allowed': list(aws.OS_SSH_INFO.keys())},
+        'allowed': list(aws.OS_AMIS.keys())},
     'instance_ami': {
         'type': 'string',
         'required': True,

--- a/dcos_launch/conftest.py
+++ b/dcos_launch/conftest.py
@@ -159,9 +159,10 @@ def mocked_gce(monkeypatch):
                         lambda _, __: [{'instance': 'mock'}])
     monkeypatch.setattr(dcos_launch.gce.BareClusterLauncher, 'key_helper', lambda self: self.config.update(
         {'ssh_private_key': dcos_launch.util.MOCK_SSH_KEY_DATA, 'ssh_public_key': dcos_launch.util.MOCK_SSH_KEY_DATA}))
-    monkeypatch.setattr(dcos_launch.gce.BareClusterLauncher, 'get_hosts', lambda self: [mock_pub_priv_host] *
-                        (1 + self.config['num_masters'] + self.config['num_public_agents'] +
+    monkeypatch.setattr(dcos_launch.gce.BareClusterLauncher, 'get_cluster_hosts', lambda self: [mock_pub_priv_host] *
+                        (self.config['num_masters'] + self.config['num_public_agents'] +
                          self.config['num_private_agents']))
+    monkeypatch.setattr(dcos_launch.gce.BareClusterLauncher, 'get_bootstrap_host', lambda self: mock_pub_priv_host)
 
 
 class MockInstaller(dcos_test_utils.onprem.DcosInstallerApiSession):
@@ -204,7 +205,9 @@ def mock_bare_cluster_hosts(monkeypatch, mocked_aws_cf, mocked_test_runner, mock
 def mocked_aws_cfstack_bare_cluster(monkeypatch, mock_bare_cluster_hosts):
     monkeypatch.setattr(dcos_launch.platforms.aws.BareClusterCfStack, '__init__', stub(None))
     monkeypatch.setattr(dcos_launch.platforms.aws.BareClusterCfStack, 'delete', stub(None))
-    monkeypatch.setattr(dcos_launch.platforms.aws.BareClusterCfStack, 'get_host_ips', stub([mock_pub_priv_host] * 4))
+    monkeypatch.setattr(
+        dcos_launch.platforms.aws.BareClusterCfStack, 'get_cluster_host_ips', stub([mock_pub_priv_host] * 4))
+    monkeypatch.setattr(dcos_launch.platforms.aws.BareClusterCfStack, 'get_bootstrap_ip', stub(mock_pub_priv_host))
     monkeypatch.setattr(
         dcos_launch.platforms.aws, 'fetch_stack', lambda stack_name,
         bw: dcos_launch.platforms.aws.BareClusterCfStack(stack_name, bw))

--- a/dcos_launch/gce.py
+++ b/dcos_launch/gce.py
@@ -13,7 +13,7 @@ from googleapiclient.errors import HttpError
 log = logging.getLogger(__name__)
 
 
-class BareClusterLauncher(util.AbstractLauncher):
+class BareClusterLauncher(util.AbstractLauncher, util.AbstractOnpremClusterLauncher):
     # Launches a homogeneous cluster of plain GMIs intended for onprem DC/OS
     def __init__(self, config: dict, env=None):
         if env is None:
@@ -78,8 +78,11 @@ class BareClusterLauncher(util.AbstractLauncher):
             self.config['ssh_private_key'] = private_key.decode()
             self.config['ssh_public_key'] = public_key.decode()
 
-    def get_hosts(self) -> [Host]:
-        return list(self.deployment.hosts)
+    def get_cluster_hosts(self) -> [Host]:
+        return list(self.deployment.hosts)[1:]
+
+    def get_bootstrap_host(self) -> Host:
+        return list(self.deployment.hosts)[0]
 
     def wait(self):
         """ Waits for the deployment to complete: first, the network that will contain the cluster is deployed. Once

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -43,10 +43,11 @@ class OnpremLauncher(dcos_launch.util.AbstractLauncher):
                 'Platform currently not supported for onprem: {}'.format(self.config['platform']))
 
     def get_onprem_cluster(self):
+        cluster_launcher = self.get_bare_cluster_launcher()
         return dcos_test_utils.onprem.OnpremCluster.from_hosts(
             ssh_client=self.get_ssh_client(),
-            bootstrap_host=self.bootstrap_host,
-            cluster_hosts=self.get_bare_cluster_launcher().get_hosts(),
+            bootstrap_host=cluster_launcher.get_bootstrap_host(),
+            cluster_hosts=cluster_launcher.get_cluster_hosts(),
             num_masters=int(self.config['num_masters']),
             num_private_agents=int(self.config['num_private_agents']),
             num_public_agents=int(self.config['num_public_agents']))

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -45,7 +45,8 @@ class OnpremLauncher(dcos_launch.util.AbstractLauncher):
     def get_onprem_cluster(self):
         return dcos_test_utils.onprem.OnpremCluster.from_hosts(
             ssh_client=self.get_ssh_client(),
-            hosts=self.get_bare_cluster_launcher().get_hosts(),
+            bootstrap_host=self.bootstrap_host,
+            cluster_hosts=self.get_bare_cluster_launcher().get_hosts(),
             num_masters=int(self.config['num_masters']),
             num_private_agents=int(self.config['num_private_agents']),
             num_public_agents=int(self.config['num_public_agents']))

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -536,11 +536,21 @@ class BareClusterCfStack(CfStack):
 
     @property
     def instances(self):
+        """ only represents the cluster instances (i.e. NOT bootstrap)
+        """
         yield from self.boto_wrapper.get_auto_scaling_instances(
             self.stack.Resource('BareServerAutoScale').physical_resource_id)
 
-    def get_host_ips(self):
+    @property
+    def bootstrap_instances(self):
+        yield from self.boto_wrapper.get_auto_scaling_instances(
+            self.stack.Resource('BootstrapServerPlaceholderAutoScale').physical_resource_id)
+
+    def get_cluster_host_ips(self):
         return instances_to_hosts(self.instances)
+
+    def get_bootstrap_ip(self):
+        return instances_to_hosts(self.bootstrap_instances)[0]
 
 
 SSH_INFO = {

--- a/dcos_launch/platforms/gce.py
+++ b/dcos_launch/platforms/gce.py
@@ -380,11 +380,16 @@ class BareClusterDeployment(Deployment):
 
     @property
     def instance_names(self):
+        # only returns the names of the
         for instance in self.gce_wrapper.list_group_instances(self.instance_group_name, self.zone):
             yield instance['instance'].split('/')[-1]
 
     @property
     def hosts(self):
+        """ order of return here determines cluster composition, so make sure its consistent
+        """
+        output_list = list()
         for name in self.instance_names:
             info = self.gce_wrapper.get_instance_network_properties(name, self.zone)
-            yield Host(private_ip=info['networkIP'], public_ip=info['accessConfigs'][0]['natIP'])
+            output_list.append(Host(private_ip=info['networkIP'], public_ip=info['accessConfigs'][0]['natIP']))
+        return sorted(output_list)

--- a/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
@@ -7,7 +7,7 @@ provider: onprem
 aws_region: us-west-2
 os_name: cent-os-7
 instance_type: m4.xlarge
-bootstrap_os_name: cento-os-7-dcos-prereqs
+bootstrap_os_name: cent-os-7-dcos-prereqs
 bootstrap_instance_type: m4.xlarge
 dcos_config:
   cluster_name: My Awesome DC/OS

--- a/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
@@ -7,6 +7,8 @@ provider: onprem
 aws_region: us-west-2
 os_name: cent-os-7
 instance_type: m4.xlarge
+bootstrap_os_name: cento-os-7-dcos-prereqs
+bootstrap_instance_type: m4.xlarge
 dcos_config:
   cluster_name: My Awesome DC/OS
   resolvers:

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -325,7 +325,7 @@
         "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
         "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
         "LaunchConfigurationName": {
-          "Ref": "BareServerLaunchConfig"
+          "Ref": "BootstrapServerPlaceholderLaunchConfig"
         },
         "MinSize": "1",
         "MaxSize": "1",

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -19,6 +19,16 @@
         "Description": "Image id of desired OS",
         "Type": "String"
     },
+    "BootstrapAmiCode": {
+      "Description": "Image id of desired OS for bootstrap node",
+      "Type": "String"
+    },
+    "BootstrapInstanceType": {
+      "Description": "EC2 PV instance type (m3.medium, etc) of the bootstrap node.",
+      "Type": "String",
+      "Default": "m4.xlarge",
+      "ConstraintDescription": "Must be a valid EC2 PV instance type"
+    },
     "ClusterSize": {
       "Default": "3",
       "MinValue": "1",
@@ -302,6 +312,68 @@
             }
           },
           {
+            "DeviceName": "/dev/sdb",
+            "VirtualName": "ephemeral0"
+          }
+        ]
+      }
+    },
+    "BootstrapServerPlaceholderAutoScale": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn" : "PublicRoute",
+      "Properties": {
+        "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
+        "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
+        "LaunchConfigurationName": {
+          "Ref": "BareServerLaunchConfig"
+        },
+        "MinSize": "1",
+        "MaxSize": "1",
+        "DesiredCapacity": "1",
+        "Tags" : [
+          {
+            "Key" : "Network",
+            "Value" : "Public",
+            "PropagateAtLaunch" : "true"
+            }
+          ]
+      }
+    },
+    "BootstrapServerPlaceholderLaunchConfig": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress": "true",
+        "ImageId": {
+          "Ref": "BootstrapAmiCode"
+        },
+        "InstanceType": {
+          "Ref": "BootstrapInstanceType"
+        },
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "ExternalSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "IamInstanceProfile": {
+          "Ref": "BareInstanceProfile"
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": "30",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
+            }
+          },
+          {
+
             "DeviceName": "/dev/sdb",
             "VirtualName": "ephemeral0"
           }

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -340,7 +340,7 @@
         "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
         "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
         "LaunchConfigurationName": {
-          "Ref": "BareServerLaunchConfig"
+          "Ref": "BootstrapServerPlaceholderLaunchConfig"
         },
         "MinSize": "1",
         "MaxSize": "1",

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -30,6 +30,16 @@
         "Description": "Image id of desired OS",
         "Type": "String"
     },
+    "BootstrapAmiCode": {
+      "Description": "Image id of desired OS for bootstrap node",
+      "Type": "String"
+    },
+    "BootstrapInstanceType": {
+      "Description": "EC2 PV instance type (m3.medium, etc.",
+      "Type": "String",
+      "Default": "m4.xlarge",
+      "ConstraintDescription": "Must be a valid EC2 PV instance type."
+    },
     "ClusterSize": {
       "Default": "3",
       "MinValue": "1",
@@ -322,6 +332,72 @@
           }
         ]
       }
-    }
+    },
+    "BootstrapServerPlaceholderAutoScale": {
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn" : "PublicRoute",
+      "Properties": {
+        "AvailabilityZones" : [{ "Fn::GetAtt" : [ "PublicSubnet", "AvailabilityZone" ] }],
+        "VPCZoneIdentifier" : [{ "Ref" : "PublicSubnet" }],
+        "LaunchConfigurationName": {
+          "Ref": "BareServerLaunchConfig"
+        },
+        "MinSize": "1",
+        "MaxSize": "1",
+        "DesiredCapacity": "1",
+        "Tags" : [
+          {
+            "Key" : "Network",
+            "Value" : "Public",
+            "PropagateAtLaunch" : "true"
+            }
+          ]
+      }
+    },
+    "BootstrapServerPlaceholderLaunchConfig": {
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Properties": {
+        "AssociatePublicIpAddress" : "true",
+        "ImageId": {
+          "Ref": "BootstrapAmiCode"
+        },
+        "InstanceType": {
+          "Ref": "BootstrapInstanceType"
+        },
+        "KeyName": {
+          "Ref": "KeyName"
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "ExternalSecurityGroup"
+          },
+          {
+            "Ref": "InternalSecurityGroup"
+          }
+        ],
+        "IamInstanceProfile": {
+            "Ref": "BareInstanceProfile"
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": "150",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "DeviceName": "/dev/sdb",
+            "Ebs": {
+              "VolumeSize": "150",
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2",
+              "SnapshotId": { "Fn::FindInMap" : [ "SDBSnapshot", { "Ref" : "AWS::Region" }, "snap"]}
+            }
+          }
+        ]
+      }
+    },
   }
 }

--- a/dcos_launch/util.py
+++ b/dcos_launch/util.py
@@ -182,3 +182,14 @@ def generate_rsa_keypair(key_size=2048):
         format=serialization.PublicFormat.OpenSSH)
 
     return privkey_pem, pubkey_pem
+
+
+class AbstractOnpremClusterLauncher(metaclass=abc.ABCMeta):
+    """ Defines the methods that an object must have to
+    support the onprem launcher
+    """
+    def get_bootstrap_host(self):
+        raise NotImplementedError()
+
+    def get_cluster_hosts(self):
+        raise NotImplementedError()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3
 botocore
 cerberus
 docopt
-git+https://github.com/dcos/dcos-test-utils@449eb8018468c0eafbc85342b68639ac89e8f6be
+git+https://github.com/dcos/dcos-test-utils@fa11830bb23e998410711b60bb854a9982c62172
 google-api-python-client
 oauth2client==3.0.0
 pyinstaller==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3
 botocore
 cerberus
 docopt
-git+https://github.com/dcos/dcos-test-utils@64baa642969f0fba598378b7811749e701ec52b9
+git+https://github.com/margaret/dcos-test-utils@64baa642969f0fba598378b7811749e701ec52b9
 google-api-python-client
 oauth2client==3.0.0
 pyinstaller==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3
 botocore
 cerberus
 docopt
-git+https://github.com/dcos/dcos-test-utils@fa11830bb23e998410711b60bb854a9982c62172
+git+https://github.com/dcos/dcos-test-utils@64baa642969f0fba598378b7811749e701ec52b9
 google-api-python-client
 oauth2client==3.0.0
 pyinstaller==3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ boto3
 botocore
 cerberus
 docopt
-git+https://github.com/margaret/dcos-test-utils@64baa642969f0fba598378b7811749e701ec52b9
+git+https://github.com/dcos/dcos-test-utils@c431eb6414e003e31c865c534b2413969a6d9947
 google-api-python-client
 oauth2client==3.0.0
 pyinstaller==3.2


### PR DESCRIPTION
Bootstrap host needs to have docker set up for the installer scripts to work, while this isn't the case with the cluster hosts.

Includes this dcos-test-utils update https://github.com/dcos/dcos-test-utils/pull/13

For https://jira.mesosphere.com/browse/QUALITY-1608

Future work https://jira.mesosphere.com/browse/QUALITY-1640