### PR TITLE
Bump `PyInstaller` version to `3.3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ docopt
 git+https://github.com/dcos/dcos-test-utils@449eb8018468c0eafbc85342b68639ac89e8f6be
 google-api-python-client
 oauth2client==3.0.0
-pyinstaller==3.2
+pyinstaller==3.3
 py
 pytest
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'docopt',
         'google-api-python-client',
         'oauth2client==3.0.0',
-        'pyinstaller==3.2',
+        'pyinstaller==3.3',
         'py',
         'pytest',
         'pyyaml',


### PR DESCRIPTION
This fixes a bug on OSX where, despite a successful build/run, the app will echo `Failed to execute script cli` to `stdout` on `sys.exit()`.  `3.3` suppresses this message.