### PR TITLE
Add bootstrap_ssh_user option

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -290,6 +290,10 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         'required': True,
         'default': '0.0.0.0/0'},
+    'bootstrap_ssh_user': {
+        'required': True,
+        'type': 'string',
+        'default_setter': lambda doc: aws.OS_SSH_INFO[doc['bootstrap_os_name']].user},
     'ssh_user': {
         'required': True,
         'type': 'string',
@@ -343,6 +347,11 @@ GCP_ONPREM_SCHEMA = {
         'type': 'string',
         'required': False,
         'default': 'pd-ssd'},
+    # FIXME: GCP needs to have an os/ssh_user mapping
+    'bootstrap_ssh_user': {
+        'required': True,
+        'type': 'string',
+        'default': 'core'},
     'disable_updates': {
         'type': 'boolean',
         'required': False,

--- a/dcos_launch/util.py
+++ b/dcos_launch/util.py
@@ -65,8 +65,8 @@ class LauncherError(Exception):
 
 
 class AbstractLauncher(metaclass=abc.ABCMeta):
-    def get_ssh_client(self):
-        return dcos_test_utils.ssh_client.SshClient(self.config['ssh_user'], self.config['ssh_private_key'])
+    def get_ssh_client(self, user='ssh_user'):
+        return dcos_test_utils.ssh_client.SshClient(self.config[user], self.config['ssh_private_key'])
 
     def __init__(self, config: dict, env=None):
         raise NotImplementedError()


### PR DESCRIPTION
Allows using a bootstrap host OS of a completely different flavor than the rest of the cluster