### PR TITLE
use AWS default session

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -8,16 +8,8 @@ log = logging.getLogger(__name__)
 
 class DcosCloudformationLauncher(dcos_launch.util.AbstractLauncher):
     def __init__(self, config: dict, env=None):
-        if env is None:
-            aws_access_key_id = dcos_launch.util.set_from_env('AWS_ACCESS_KEY_ID')
-            aws_secret_access_key = dcos_launch.util.set_from_env('AWS_SECRET_ACCESS_KEY')
-        else:
-            aws_access_key_id = env['AWS_ACCESS_KEY_ID']
-            aws_secret_access_key = env['AWS_SECRET_ACCESS_KEY']
         self.boto_wrapper = dcos_launch.platforms.aws.BotoWrapper(
-            config['aws_region'],
-            aws_access_key_id,
-            aws_secret_access_key)
+            config['aws_region'])
         self.config = config
 
     def create(self):

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -105,10 +105,9 @@ def fetch_stack(stack_name, boto_wrapper):
 
 
 class BotoWrapper:
-    def __init__(self, region, aws_access_key_id, aws_secret_access_key):
+    def __init__(self, region):
         self.region = region
-        self.session = boto3.session.Session(
-            aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key)
+        self.session = boto3.session.Session()
 
     @retry_boto_rate_limits
     def client(self, name):


### PR DESCRIPTION
This removes the dependency to a single way of getting an AWS session.

With this patch dcos-launch supports:
- instance profiles
- profiles
- session tokens
- static keys