### PR TITLE
Configurable instance [disk] device names

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -136,10 +136,12 @@ class BareClusterLauncher(DcosCloudformationLauncher, dcos_launch.util.AbstractO
             'ClusterSize': (self.config['num_masters'] + self.config['num_public_agents'] +
                             self.config['num_private_agents']),
             'InstanceType': self.config['instance_type'],
+            'InstanceDeviceName': self.config['instance_device_name'],
             'AmiCode': self.config['instance_ami'],
             # Bootstrap instance is currently instantiated as a single-server AutoScaleGroup which is terrible and is
             # intended to be updated to be configured properly as an EC2 instance later
             'BootstrapInstanceType': self.config['bootstrap_instance_type'],
+            'BootstrapInstanceDeviceName': self.config['bootstrap_instance_device_name'],
             'BootstrapAmiCode': self.config['bootstrap_instance_ami']
         }
         if not self.config['key_helper']:

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -371,6 +371,10 @@ AWS_ONPREM_SCHEMA = {
     'instance_type': {
         'type': 'string',
         'required': True},
+    'instance_device_name': {
+        'type': 'string',
+        'required': True,
+        'default': '/dev/sda1'},
     'bootstrap_instance_ami': {
         'type': 'string',
         'required': True,
@@ -379,6 +383,10 @@ AWS_ONPREM_SCHEMA = {
         'type': 'string',
         'required': True,
         'default': 'm4.xlarge'},
+    'bootstrap_instance_device_name': {
+        'type': 'string',
+        'required': True,
+        'default': '/dev/sda1'},
     'admin_location': {
         'type': 'string',
         'required': True,

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -15,6 +15,12 @@
       "Default": "m4.xlarge",
       "ConstraintDescription": "Must be a valid EC2 PV instance type."
     },
+    "InstanceDeviceName": {
+      "Description": "Disk device name (/dev/sda1, /dev/xdva, etc).",
+      "Type": "String",
+      "Default": "/dev/sda1",
+      "ConstraintDescription": "Must be a valid device name."
+    },
     "AmiCode": {
         "Description": "Image id of desired OS",
         "Type": "String"
@@ -28,6 +34,12 @@
       "Type": "String",
       "Default": "m4.xlarge",
       "ConstraintDescription": "Must be a valid EC2 PV instance type"
+    },
+    "BootstrapInstanceDeviceName": {
+      "Description": "Disk device name used on the bootstrap node.",
+      "Type": "String",
+      "Default": "/dev/sda1",
+      "ConstraintDescription": "Must be a valid device name."
     },
     "ClusterSize": {
       "Default": "3",
@@ -304,16 +316,14 @@
         },
         "BlockDeviceMappings": [
           {
-            "DeviceName": "/dev/sda1",
+            "DeviceName": {
+              "Ref": "InstanceDeviceName"
+            },
             "Ebs": {
               "VolumeSize": "30",
               "DeleteOnTermination": "true",
               "VolumeType": "gp2"
             }
-          },
-          {
-            "DeviceName": "/dev/sdb",
-            "VirtualName": "ephemeral0"
           }
         ]
       }
@@ -365,17 +375,14 @@
         },
         "BlockDeviceMappings": [
           {
-            "DeviceName": "/dev/sda1",
+            "DeviceName": {
+              "Ref": "BootstrapInstanceDeviceName"
+            },
             "Ebs": {
               "VolumeSize": "30",
               "DeleteOnTermination": "true",
               "VolumeType": "gp2"
             }
-          },
-          {
-
-            "DeviceName": "/dev/sdb",
-            "VirtualName": "ephemeral0"
           }
         ]
       }

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -5,17 +5,6 @@
     "SubnetConfig" : {
       "VPC"     : { "CIDR" : "10.10.0.0/16" },
       "Public"  : { "CIDR" : "10.10.0.0/24" }
-    },
-    "SDBSnapshot": {
-      "us-west-2": {"snap": "snap-00ae1a58"},
-      "us-west-1": {"snap": "snap-2f2c1516"},
-      "sa-east-1": {"snap": "snap-356b2302"},
-      "us-east-1": {"snap": "snap-5f580f42"},
-      "ap-southeast-1": {"snap": "snap-a7be23b6"},
-      "ap-southeast-2": {"snap": "snap-e1f4bfed"},
-      "ap-northeast-1": {"snap": "snap-b970ec81"},
-      "eu-west-1": {"snap": "snap-056ada2d"},
-      "eu-central-1": {"snap": "snap-2c830027"}
     }
   },
   "Parameters": {
@@ -25,6 +14,12 @@
       "Type": "String",
       "Default": "m4.xlarge",
       "ConstraintDescription": "Must be a valid EC2 PV instance type."
+    },
+    "InstanceDeviceName": {
+      "Description": "Disk device name (/dev/sda1, /dev/xdva, etc).",
+      "Type": "String",
+      "Default": "/dev/sda1",
+      "ConstraintDescription": "Must be a valid device name."
     },
     "AmiCode": {
         "Description": "Image id of desired OS",
@@ -39,6 +34,12 @@
       "Type": "String",
       "Default": "m4.xlarge",
       "ConstraintDescription": "Must be a valid EC2 PV instance type."
+    },
+    "BootstrapInstanceDeviceName": {
+      "Description": "Disk device name used on the bootstrap node.",
+      "Type": "String",
+      "Default": "/dev/sda1",
+      "ConstraintDescription": "Must be a valid device name."
     },
     "ClusterSize": {
       "Default": "3",
@@ -314,20 +315,13 @@
         },
         "BlockDeviceMappings": [
           {
-            "DeviceName": "/dev/sda1",
+            "DeviceName": {
+              "Ref": "InstanceDeviceName"
+            },
             "Ebs": {
               "VolumeSize": "150",
               "DeleteOnTermination": "true",
               "VolumeType": "gp2"
-            }
-          },
-          {
-            "DeviceName": "/dev/sdb",
-            "Ebs": {
-              "VolumeSize": "150",
-              "DeleteOnTermination": "true",
-              "VolumeType": "gp2",
-              "SnapshotId": { "Fn::FindInMap" : [ "SDBSnapshot", { "Ref" : "AWS::Region" }, "snap"]}
             }
           }
         ]
@@ -380,20 +374,13 @@
         },
         "BlockDeviceMappings": [
           {
-            "DeviceName": "/dev/sda1",
+            "DeviceName": {
+              "Ref": "BootstrapInstanceDeviceName"
+            },
             "Ebs": {
               "VolumeSize": "150",
               "DeleteOnTermination": "true",
               "VolumeType": "gp2"
-            }
-          },
-          {
-            "DeviceName": "/dev/sdb",
-            "Ebs": {
-              "VolumeSize": "150",
-              "DeleteOnTermination": "true",
-              "VolumeType": "gp2",
-              "SnapshotId": { "Fn::FindInMap" : [ "SDBSnapshot", { "Ref" : "AWS::Region" }, "snap"]}
             }
           }
         ]


### PR DESCRIPTION
This PR allows CF-initiated VPC instances (and bootstrap instances) to have
configurable disk device names.

Some Linux-based AMIs (CoreOS HVM, specifically) have differing disk
device naming[1]; hard-coding `/dev/sda` will cause provisioned instances
to fail and be terminated upon boot, and Auto Scaling Groups will
re-provision instances until the end of time.  $$$

The following parameters are introduced:

dcos-launch

- `instance_device_name`
- `bootstrap_instance_device_name`

CloudFormation templates

- `InstanceDeviceName`
- `BootstrapInstanceDeviceName`

No changes for non-CoreOS deployments are required; `/dev/sda1` is still
the default.  CoreOS users should use `/dev/xvda`.

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html