### PR TITLE
refactor onprem launchers' inheritance flow

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+not_skip=__init__.py
+skip=.git,.tox,__pycache__,lib,bin,include

--- a/dcos_launch/__init__.py
+++ b/dcos_launch/__init__.py
@@ -1,10 +1,9 @@
-import dcos_launch.arm
 import dcos_launch.acs_engine
+import dcos_launch.arm
 import dcos_launch.aws
 import dcos_launch.gcp
 import dcos_launch.onprem
 import dcos_launch.util
-
 
 VERSION = '0.1.0'
 
@@ -18,12 +17,12 @@ def get_launcher(config, env=None):
         if provider == 'aws':
             return dcos_launch.aws.DcosCloudformationLauncher(config, env=env)
         if provider == 'onprem':
-            return dcos_launch.onprem.OnpremLauncher(config, env=env)
+            return dcos_launch.aws.OnPremLauncher(config, env=env)
     if platform == 'azure':
         if provider == 'azure':
             return dcos_launch.arm.AzureResourceGroupLauncher(config, env=env)
         if provider == 'acs-engine':
             return dcos_launch.acs_engine.ACSEngineLauncher(config, env=env)
     if platform == 'gcp':
-        return dcos_launch.onprem.OnpremLauncher(config, env=env)
+        return dcos_launch.gcp.OnPremLauncher(config, env=env)
     raise dcos_launch.util.LauncherError('UnsupportedAction', 'Launch platform not supported: {}'.format(platform))

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -10,8 +10,8 @@ import uuid
 
 import requests
 
-import dcos_launch.util
 import dcos_launch.platforms.arm
+import dcos_launch.util
 
 log = logging.getLogger(__name__)
 

--- a/dcos_launch/arm.py
+++ b/dcos_launch/arm.py
@@ -2,8 +2,8 @@
 """
 import logging
 
-import dcos_launch.util
 import dcos_launch.platforms.arm
+import dcos_launch.util
 
 log = logging.getLogger(__name__)
 

--- a/dcos_launch/cli.py
+++ b/dcos_launch/cli.py
@@ -35,12 +35,11 @@ import json
 import os
 import sys
 
-from docopt import docopt
-
 import dcos_launch
 import dcos_launch.config
 import dcos_launch.util
 from dcos_test_utils import logger
+from docopt import docopt
 
 json_prettyprint_args = {
     "sort_keys": True,

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -3,10 +3,10 @@
 import os
 import sys
 
-import cerberus
 import pkg_resources
-import yaml
 
+import cerberus
+import yaml
 from dcos_launch import util
 from dcos_launch.platforms import aws, gcp
 

--- a/dcos_launch/gcp.py
+++ b/dcos_launch/gcp.py
@@ -4,16 +4,15 @@ import json
 import logging
 import os
 
-from dcos_launch import util
+from dcos_launch import onprem, util
 from dcos_launch.platforms import gcp
 from dcos_test_utils.helpers import Host
-
 from googleapiclient.errors import HttpError
 
 log = logging.getLogger(__name__)
 
 
-class BareClusterLauncher(util.AbstractLauncher, util.AbstractOnpremClusterLauncher):
+class OnPremLauncher(onprem.AbstractOnpremLauncher):
     # Launches a homogeneous cluster of plain GMIs intended for onprem DC/OS
     def __init__(self, config: dict, env=None):
         if env is None:
@@ -93,12 +92,10 @@ class BareClusterLauncher(util.AbstractLauncher, util.AbstractOnpremClusterLaunc
         once the instance template is deployed, an instance group manager and all its instances are deployed.
         """
         self.deployment.wait_for_completion()
+        super().wait()
 
     def delete(self):
         """ Deletes all the resources associated with the deployment (instance template, network, firewall, instance
         group manager and all its instances.
         """
         self.deployment.delete()
-
-    def test(self, args, env_dict, test_host=None, test_port=22):
-        raise NotImplementedError('Bare clusters cannot be tested!')

--- a/dcos_launch/platforms/arm.py
+++ b/dcos_launch/platforms/arm.py
@@ -10,6 +10,7 @@ import logging
 import re
 
 import requests
+
 import retrying
 from azure.common.credentials import ServicePrincipalCredentials
 from azure.common.exceptions import CloudError
@@ -19,7 +20,6 @@ from azure.mgmt.resource.resources.v2016_02_01.models import (DeploymentMode,
                                                               DeploymentProperties,
                                                               ResourceGroup)
 from azure.monitor import MonitorClient
-
 from dcos_test_utils.helpers import Host
 
 log = logging.getLogger(__name__)

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -15,15 +15,16 @@ PrivateAgentStack: thin wrapper for public agent stack in a zen template
 PublicAgentStack: thin wrapper for public agent stack in a zen template
 BareClusterCfStack: Represents a homogeneous cluster of hosts with a specific AMI
 """
-import logging
 import copy
-import time
-import pkg_resources
-import retrying
 import functools
-import boto3
-from botocore.exceptions import ClientError, WaiterError
+import logging
+import time
 
+import pkg_resources
+
+import boto3
+import retrying
+from botocore.exceptions import ClientError, WaiterError
 from dcos_test_utils.helpers import Host, SshInfo
 
 log = logging.getLogger(__name__)
@@ -361,7 +362,6 @@ class CleanupS3BucketMixin:
         except Exception:
             # Exhibitor S3 Bucket might not be a resource
             log.exception('Failed to get S3 bucket physical ID')
-        super().delete()
 
 
 class DcosCfStack(CleanupS3BucketMixin, CfStack):

--- a/dcos_launch/platforms/gcp.py
+++ b/dcos_launch/platforms/gcp.py
@@ -6,15 +6,14 @@ Cloud Deployment Manager results in simpler code and far fewer API calls.
 import copy
 import logging
 import typing
-import yaml
 from functools import wraps
 
+import yaml
+from dcos_test_utils.helpers import Host
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 from oauth2client.service_account import ServiceAccountCredentials
 from retrying import retry
-
-from dcos_test_utils.helpers import Host
 
 log = logging.getLogger(__name__)
 

--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -6,10 +6,8 @@ import os
 import sys
 
 import retrying
-
-from dcos_test_utils import onprem, ssh_client
-
 from dcos_launch import util
+from dcos_test_utils import onprem, ssh_client
 
 log = logging.getLogger(__name__)
 

--- a/dcos_launch/util.py
+++ b/dcos_launch/util.py
@@ -6,11 +6,11 @@ import sys
 
 import cryptography.hazmat.backends
 import pkg_resources
-import yaml
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 import dcos_test_utils
+import yaml
 
 log = logging.getLogger(__name__)
 
@@ -181,14 +181,3 @@ def generate_rsa_keypair(key_size=2048):
         format=serialization.PublicFormat.OpenSSH)
 
     return privkey_pem, pubkey_pem
-
-
-class AbstractOnpremClusterLauncher(metaclass=abc.ABCMeta):
-    """ Defines the methods that an object must have to
-    support the onprem launcher
-    """
-    def get_bootstrap_host(self):
-        raise NotImplementedError()
-
-    def get_cluster_hosts(self):
-        raise NotImplementedError()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,6 @@ import json
 from collections import namedtuple
 from contextlib import contextmanager
 
-import pytest
-
 import dcos_launch
 import dcos_launch.cli
 import dcos_launch.config
@@ -12,6 +10,7 @@ import dcos_launch.onprem
 import dcos_launch.platforms
 import dcos_test_utils
 import dcos_test_utils.ssh_client
+import pytest
 from dcos_launch.util import get_temp_config_path, stub
 from dcos_test_utils.helpers import Host
 
@@ -173,12 +172,13 @@ def mocked_gcp(monkeypatch, mock_ssh_client):
                         lambda _, __: MOCK_GCE_INSTANCE_INFO)
     monkeypatch.setattr(dcos_launch.platforms.gcp.GcpWrapper, 'list_group_instances',
                         lambda _, __: [{'instance': 'mock'}])
-    monkeypatch.setattr(dcos_launch.gcp.BareClusterLauncher, 'key_helper', lambda self: self.config.update(
+    monkeypatch.setattr(dcos_launch.gcp.OnPremLauncher, 'key_helper', lambda self: self.config.update(
         {'ssh_private_key': dcos_launch.util.MOCK_SSH_KEY_DATA, 'ssh_public_key': dcos_launch.util.MOCK_SSH_KEY_DATA}))
-    monkeypatch.setattr(dcos_launch.gcp.BareClusterLauncher, 'get_cluster_hosts', lambda self: [mock_pub_priv_host] *
-                        (self.config['num_masters'] + self.config['num_public_agents'] +
-                         self.config['num_private_agents']))
-    monkeypatch.setattr(dcos_launch.gcp.BareClusterLauncher, 'get_bootstrap_host', lambda self: mock_pub_priv_host)
+    monkeypatch.setattr(dcos_launch.gcp.OnPremLauncher, 'get_cluster_hosts',
+                        lambda self: [mock_pub_priv_host] * (self.config['num_masters'] +
+                                                             self.config['num_public_agents'] +
+                                                             self.config['num_private_agents']))
+    monkeypatch.setattr(dcos_launch.gcp.OnPremLauncher, 'get_bootstrap_host', lambda self: mock_pub_priv_host)
 
 
 @pytest.fixture

--- a/test/test_aws.py
+++ b/test/test_aws.py
@@ -1,10 +1,9 @@
-import pytest
-
 import dcos_launch
 import dcos_launch.cli
 import dcos_launch.config
-import dcos_launch.util
 import dcos_launch.platforms.aws
+import dcos_launch.util
+import pytest
 
 
 def test_aws_cf_simple(check_cli_success, aws_cf_config_path):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,9 +2,8 @@ import re
 import shutil
 
 import pytest
-from docopt import DocoptExit
-
 from dcos_launch.cli import main
+from docopt import DocoptExit
 
 
 def test_no_files_specified(tmpdir, aws_cf_config_path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-
 from dcos_launch.config import LaunchValidator, get_validated_config_from_path
 from dcos_launch.util import LauncherError, get_temp_config_path
 

--- a/test/test_onprem.py
+++ b/test/test_onprem.py
@@ -1,10 +1,10 @@
 import collections
 import json
 import subprocess
-import dcos_test_utils
-from dcos_test_utils import helpers
 
 import dcos_launch
+import dcos_test_utils
+from dcos_test_utils import helpers
 
 
 def test_aws_onprem(check_cli_success, aws_onprem_config_path):


### PR DESCRIPTION
The mechanism in the OnpremLauncher of:
get_bare_cluster_launcher -> call some method in BareClusterLauncher
reduced to:
directly calling the BareClusterLauncher methods by using inheritance. BareClusterLaunchers are now OnpremLaunchers inheriting from an AbstractOnpremLauncher class
This also removed the need for classes like: AbstractOnpremClusterLauncher

the rest of the changes are just isort