### PR TITLE
Enable dcos-launch with acs-engine for Hybrid Cloud CI

### DIFF
--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -173,6 +173,9 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
             self.config['windows_admin_user'],
             self.config['windows_admin_password'],
             self.config['linux_admin_user'])
+        windows_image_source_url = self.config.get('windows_image_source_url')
+        if windows_image_source_url:
+            acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -39,7 +39,8 @@ def generate_acs_engine_template(
         "apiVersion": "vlabs",
         "properties": {
             "orchestratorProfile": {
-                "orchestratorType": "DCOS"
+                "orchestratorType": "DCOS",
+                "orchestratorVersion": "1.11.0"
             },
             "masterProfile": {
                 "count": num_masters,
@@ -177,9 +178,18 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
         if windows_image_source_url:
             acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
+        linux_repository_url = self.config.get('dcos_linux_repository_url')
+        linux_cluster_package_list_id = self.config.get('dcos_linux_cluster_package_list_id')
+        provider_package_id = self.config.get('provider_package_id')
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:
             self.config['template_parameters']['dcosBootstrapURL'] = linux_bs_url
+        if linux_repository_url:
+            self.config['template_parameters']['dcosRepositoryURL'] = linux_repository_url
+        if linux_cluster_package_list_id:
+            self.config['template_parameters']['dcosClusterPackageListID'] = linux_cluster_package_list_id
+        if provider_package_id:
+            self.config['template_parameters']['dcosProviderPackageID'] = provider_package_id
         self.azure_wrapper.deploy_template_to_new_resource_group(
             self.config.get('template_url'),
             self.config['deployment_name'],

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -218,7 +218,7 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
     def delete(self):
         self.resource_group.delete()
 
-    def test(self, args: list, env_dict: dict, test_host=None, test_port=22, details: dict=None) -> int:
+    def test(self, args: list, env_dict: dict, test_host=None, test_port=2200, details: dict=None) -> int:
         details = self.describe()
         env_dict.update({
             'WINDOWS_HOSTS': ','.join(m['private_ip'] for m in details['windows_private_agents']),

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -509,6 +509,15 @@ ACS_ENGINE_SCHEMA = {
     'windows_image_source_url': {
         'type': 'string',
         'required': False},
+    'dcos_linux_repository_url': {
+        'type': 'string',
+        'required': False},
+    'dcos_linux_cluster_package_list_id': {
+        'type': 'string',
+        'required': False},
+    'provider_package_id': {
+        'type': 'string',
+        'required': False},
     'ssh_user': {
         'type': 'string',
         'required': True,

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -506,6 +506,9 @@ ACS_ENGINE_SCHEMA = {
     'dcos_linux_bootstrap_url': {
         'type': 'string',
         'required': False},
+    'windows_image_source_url': {
+        'type': 'string',
+        'required': False},
     'ssh_user': {
         'type': 'string',
         'required': True,


### PR DESCRIPTION
This pull request adds the following updates:

- Add support for changing the DC/OS Windows image being used to a custom generated one
- Change default `test_port` to `2200`
- Add support for custom packages

## Corresponding DC/OS tickets

  - [DCOS_OSS-2078](https://jira.mesosphere.com/browse/DCOS_OSS-2078) Integrate Hybrid DC/OS Cluster into CI/CD.