### PR TITLE
Add CREATE_COMPLETE to transition states of delete on AWS stack

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -87,7 +87,9 @@ class DcosCloudformationLauncher(dcos_launch.util.AbstractLauncher):
         if len(self.config['temp_resources']) > 0:
             # must wait for stack to be deleted before removing
             # network resources on which it depends
-            self.stack.wait_for_complete(transition_states=['DELETE_IN_PROGRESS'], end_states=['DELETE_COMPLETE'])
+            self.stack.wait_for_complete(
+                transition_states=['CREATE_COMPLETE', 'DELETE_IN_PROGRESS'],
+                end_states=['DELETE_COMPLETE'])
             self.delete_temp_resources(self.config['temp_resources'])
 
     def delete_temp_resources(self, temp_resources):


### PR DESCRIPTION
https://jira.mesosphere.com/browse/QUALITY-1963

This line has last been touched seven months ago https://github.com/dcos/dcos-launch/commit/94141d9570381b55288360ac7a04a201ab7f3310 so not sure why this is starting to fail now. I'm guessing that somehow the CF status is just a tiny bit slower to update the stack state after [calling boto's delete stack function](https://github.com/dcos/dcos-launch/blob/b0fe1896a51346b4bbb7780783e065ad09128ec8/dcos_launch/aws.py#L86), and that check is being called before it changes to DELETE_IN_PROGRESS from CREATE_COMPLETE. I tried creating and deleting a bunch of clusters at different commits between 57d91fb7f582e9687ceca132c1d085e4c144e86c and current master but it seemed nondeterministic. Short of spending $12398471 on AWS investigating this more, just going to add the CREATE_COMPLETE state.