### PR TITLE
Stop hardcoding the name of the package in `pkg_resources.resource_st…

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -6,6 +6,7 @@ import sys
 import pkg_resources
 
 import cerberus
+import dcos_launch
 import yaml
 from dcos_launch import util
 from dcos_launch.platforms import aws, gcp
@@ -331,7 +332,7 @@ ONPREM_DEPLOY_COMMON_SCHEMA = {
         'coerce': 'expand_local_path',
         'required': False,
         'default_setter':
-            lambda doc: pkg_resources.resource_filename('dcos_launch', 'scripts/install_prereqs.sh') \
+            lambda doc: pkg_resources.resource_filename(dcos_launch.__name__, 'scripts/install_prereqs.sh') \
             if doc['install_prereqs'] else ''
     },
     'install_prereqs': {

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -7,6 +7,7 @@ import typing
 
 import pkg_resources
 
+import dcos_launch
 import yaml
 from dcos_launch import util
 from dcos_launch.platforms import onprem as platforms_onprem
@@ -109,7 +110,7 @@ class AbstractOnpremLauncher(util.AbstractLauncher, metaclass=abc.ABCMeta):
             # use a sensible default
             shutil.copyfile(
                 pkg_resources.resource_filename(
-                    'dcos_launch', script_hyphen + '/{}.sh'.format(self.config['platform'])),
+                    dcos_launch.__name__, script_hyphen + '/{}.sh'.format(self.config['platform'])),
                 default_path_local)
 
         with open(os.path.join(genconf_dir, 'config.yaml'), 'w') as f:

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -27,14 +27,16 @@ import retrying
 from botocore.exceptions import ClientError, WaiterError
 from dcos_test_utils.helpers import Host, SshInfo
 
+import dcos_launch
+
 log = logging.getLogger(__name__)
 
 
 def template_by_instance_type(instance_type):
     if instance_type.split('.')[0] in ('c4', 't2', 'm4'):
-        template = pkg_resources.resource_string('dcos_launch', 'templates/vpc-ebs-only-cluster-template.json')
+        template = pkg_resources.resource_string(dcos_launch.__name__, 'templates/vpc-ebs-only-cluster-template.json')
     else:
-        template = pkg_resources.resource_string('dcos_launch', 'templates/vpc-cluster-template.json')
+        template = pkg_resources.resource_string(dcos_launch.__name__, 'templates/vpc-cluster-template.json')
     return template.decode('utf-8')
 
 

--- a/dcos_launch/util.py
+++ b/dcos_launch/util.py
@@ -9,6 +9,7 @@ import pkg_resources
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+import dcos_launch
 import dcos_test_utils
 import yaml
 
@@ -45,7 +46,7 @@ def stub(output):
 
 def get_temp_config_path(tmpdir, name, update: dict = None):
     config = yaml.load(
-        pkg_resources.resource_string('dcos_launch', 'sample_configs/{}'.format(name)).decode('utf-8'))
+        pkg_resources.resource_string(dcos_launch.__name__, 'sample_configs/{}'.format(name)).decode('utf-8'))
     if update is not None:
         config.update(update)
     new_config_path = tmpdir.join('my_config.yaml')


### PR DESCRIPTION
…rings. This allows for vendoring `dcos_launch` under an alternative name

In DC/OS E2E we vendor DC/OS Launch.
`dcos_launch` in that environment is actually `dcos_e2e._vendor.dcos_launch`.
Right now we manually change the strings `'dcos_launch'` to `'dcos_e2e._vendor.dcos_launch'`.

This change should make no difference to `dcos_launch` and it should make the lives of us maintainers of DC/OS E2E a little easier. https://github.com/mesosphere/dcos-e2e/pull/695/files is the E2E PR which demonstrates the contributing instructions that can be removed given this change.

Usually I'd be wary of changing Launch for such a custom use case, but to me this is a simple change that does not add maintenance burden, I hope.