### PR TITLE
Allow specifying custom IAM permissions and add KubernetesCluster tag

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import dcos_launch.util
@@ -147,6 +148,11 @@ class OnPremLauncher(DcosCloudformationLauncher, onprem.AbstractOnpremLauncher):
         }
         if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']
+        template_body = dcos_launch.platforms.aws.template_by_instance_type(self.config['instance_type']),
+        if 'iam_role_permissions' in self.config:
+            template_body_json = json.loads(template_body)
+            template_body_json['Resources']['BareRole']['Policies'][0]['PolicyDocument']['Statement'].extend(
+                self.config['iam_role_permissions'])
         self.config.update({
             'template_body': aws.template_by_instance_type(self.config['instance_type']),
             'template_parameters': template_parameters})

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -151,7 +151,8 @@ class OnPremLauncher(DcosCloudformationLauncher, onprem.AbstractOnpremLauncher):
         template_body = dcos_launch.platforms.aws.template_by_instance_type(self.config['instance_type'])
         if 'iam_role_permissions' in self.config:
             template_body_json = json.loads(template_body)
-            template_body_json['Resources']['BareRole']['Policies'][0]['PolicyDocument']['Statement'].extend(
+            template_body_json[
+                'Resources']['BareRole']['Properties']['Policies'][0]['PolicyDocument']['Statement'].extend(
                 self.config['iam_role_permissions'])
             template_body = json.dumps(template_body_json)
         self.config.update({

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -153,8 +153,9 @@ class OnPremLauncher(DcosCloudformationLauncher, onprem.AbstractOnpremLauncher):
             template_body_json = json.loads(template_body)
             template_body_json['Resources']['BareRole']['Policies'][0]['PolicyDocument']['Statement'].extend(
                 self.config['iam_role_permissions'])
+            template_body = json.dumps(template_body_json)
         self.config.update({
-            'template_body': aws.template_by_instance_type(self.config['instance_type']),
+            'template_body': template_body,
             'template_parameters': template_parameters})
         return DcosCloudformationLauncher.create(self)
 

--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -148,7 +148,7 @@ class OnPremLauncher(DcosCloudformationLauncher, onprem.AbstractOnpremLauncher):
         }
         if not self.config['key_helper']:
             template_parameters['KeyName'] = self.config['aws_key_name']
-        template_body = dcos_launch.platforms.aws.template_by_instance_type(self.config['instance_type']),
+        template_body = dcos_launch.platforms.aws.template_by_instance_type(self.config['instance_type'])
         if 'iam_role_permissions' in self.config:
             template_body_json = json.loads(template_body)
             template_body_json['Resources']['BareRole']['Policies'][0]['PolicyDocument']['Statement'].extend(

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -422,6 +422,24 @@ AWS_ONPREM_SCHEMA = {
         'required': True,
         'type': 'string',
         'default_setter': lambda doc: aws.OS_SSH_INFO[doc['os_name']].user},
+    'iam_role_persmissions': {
+        'required': False,
+        'type': 'list',
+        'valueschema': {
+            'type': 'dict',
+            'schema': {
+                'Resource': {
+                    'type': 'list',
+                    'required': True},
+                'Action': {
+                    'required': True,
+                    'type': 'list'},
+                'Effect': {
+                    'required': True,
+                    'allowed': ['Allow', 'Deny']}
+            }
+        }
+    }
 }
 
 

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -422,7 +422,7 @@ AWS_ONPREM_SCHEMA = {
         'required': True,
         'type': 'string',
         'default_setter': lambda doc: aws.OS_SSH_INFO[doc['os_name']].user},
-    'iam_role_persmissions': {
+    'iam_role_permissions': {
         'required': False,
         'type': 'list',
         'valueschema': {

--- a/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
@@ -1,0 +1,30 @@
+---
+launch_config_version: 1
+deployment_name: dcos-onprem-with-new-stack
+installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
+platform: aws
+provider: onprem
+aws_region: us-west-2
+os_name: cent-os-7
+instance_type: m4.large
+bootstrap_os_name: cent-os-7-dcos-prereqs
+bootstrap_instance_type: m4.xlarge
+dcos_config:
+  cluster_name: My Awesome DC/OS
+  resolvers:
+    - 8.8.4.4
+    - 8.8.8.8
+  dns_search: mesos
+  master_discovery: static
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+ssh_user: centos
+key_helper: true
+iam_role_persmissions:
+  - Resource: '*'
+    Action:
+      - 'ec2:DescribeSnapshotAttribute'
+      - 'elasticloadbalancing:*'
+      - 'ec2:*'
+    Effect: 'Allow'

--- a/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
@@ -24,7 +24,10 @@ key_helper: true
 iam_role_permissions:
   - Resource: '*'
     Action:
-      - 'ec2:DescribeSnapshotAttribute'
-      - 'elasticloadbalancing:*'
-      - 'ec2:*'
-    Effect: 'Allow'
+      - ec2:DescribeSnapshotAttribute
+      - elasticloadbalancing:*
+      - ec2:*
+    Effect: Allow
+tags:
+  KubernetesCluster: foobar-cluster
+  expiration: 24h

--- a/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-extra-iam.yaml
@@ -21,7 +21,7 @@ num_private_agents: 1
 num_public_agents: 1
 ssh_user: centos
 key_helper: true
-iam_role_persmissions:
+iam_role_permissions:
   - Resource: '*'
     Action:
       - 'ec2:DescribeSnapshotAttribute'

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -202,6 +202,9 @@
             "ToPort": "65535",
             "SourceSecurityGroupId": { "Ref" : "ExternalSecurityGroup"}
           }
+        ],
+        "Tags" : [
+          { "Key" : "KubernetesCluster", "Value" : { "Ref" : "AWS::StackName" } }
         ]
       }
     },
@@ -287,8 +290,13 @@
             "Key" : "Network",
             "Value" : "Public",
             "PropagateAtLaunch" : "true"
-            }
-          ]
+          },
+          {
+            "Key" : "KubernetesCluster",
+            "Value" : { "Ref" : "AWS::StackName" },
+            "PropagateAtLaunch" : "true"
+          }
+        ]
       }
     },
     "BareServerLaunchConfig": {
@@ -346,8 +354,8 @@
             "Key" : "Network",
             "Value" : "Public",
             "PropagateAtLaunch" : "true"
-            }
-          ]
+          }
+        ]
       }
     },
     "BootstrapServerPlaceholderLaunchConfig": {

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -223,7 +223,8 @@
           "PolicyName": "BareServers",
           "PolicyDocument": {
             "Version" : "2012-10-17",
-            "Statement": [ {
+            "Statement": [
+            {
               "Resource": [
                   { "Ref" : "AWS::StackId" },
                   { "Fn::Join" : ["", [{ "Ref" : "AWS::StackId" }, "/*" ]]}

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -293,7 +293,8 @@
             "Key" : "KubernetesCluster",
             "Value" : { "Ref" : "AWS::StackName" },
             "PropagateAtLaunch" : "true"
-          ]
+          }
+        ]
       }
     },
     "BareServerLaunchConfig": {
@@ -392,6 +393,6 @@
           }
         ]
       }
-    },
+    }
   }
 }

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -202,6 +202,9 @@
             "ToPort": "65535",
             "SourceSecurityGroupId": { "Ref" : "ExternalSecurityGroup"}
           }
+        ],
+        "Tags" : [
+          { "Key" : "KubernetesCluster", "Value" : { "Ref" : "AWS::StackName" } }
         ]
       }
     },
@@ -285,7 +288,11 @@
             "Key" : "Network",
             "Value" : "Public",
             "PropagateAtLaunch" : "true"
-            }
+          },
+          {
+            "Key" : "KubernetesCluster",
+            "Value" : { "Ref" : "AWS::StackName" },
+            "PropagateAtLaunch" : "true"
           ]
       }
     },

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -240,6 +240,11 @@ def aws_onprem_with_helper_config_path(tmpdir, mocked_aws_cfstack_bare_cluster):
 
 
 @pytest.fixture
+def aws_onprem_with_extra_iam_config_path(tmpdir, mocked_aws_cfstack_bare_cluster):
+    return get_temp_config_path(tmpdir, 'aws-onprem-with-extra-iam.yaml')
+
+
+@pytest.fixture
 def mock_genconf_dir(tmpdir):
     """ For testing genconf_dir and providing onprem configuration via a local
         genconf dir. Similarly, the DC/OS config can be provided by a 'dcos_config' field

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -86,6 +86,9 @@ class TestAwsOnprem:
     def test_with_genconf(self, aws_onprem_with_genconf_config_path):
         get_validated_config_from_path(aws_onprem_with_genconf_config_path)
 
+    def test_with_extra_iam(self, aws_onprem_with_extra_iam_config_path):
+        get_validated_config_from_path(aws_onprem_with_extra_iam_config_path)
+
     def test_error_is_skipped_in_nested_config(self, tmpdir):
         get_validated_config_from_path(
             get_temp_config_path(

--- a/test/test_onprem.py
+++ b/test/test_onprem.py
@@ -22,6 +22,14 @@ def test_aws_onprem_with_helper(check_cli_success, aws_onprem_with_helper_config
     assert 'KeyName' in info['template_parameters']
 
 
+def test_aws_onprem_with_extra_iam(check_cli_success, aws_onprem_with_extra_iam_config_path):
+    info, desc = check_cli_success(aws_onprem_with_extra_iam_config_path)
+    assert 'stack_id' in info
+    assert info['ssh_private_key'] == dcos_launch.util.MOCK_SSH_KEY_DATA
+    assert 'template_body' not in desc  # distracting irrelevant information
+    assert 'KeyName' in info['template_parameters']
+
+
 def test_gcp_onprem(check_cli_success, gcp_onprem_config_path):
     info, desc = check_cli_success(gcp_onprem_config_path)
     assert info['ssh_private_key'] == dcos_launch.util.MOCK_SSH_KEY_DATA


### PR DESCRIPTION
provides new 'iam_role_permissions' field which allows specifying customized additional iam role permissions to be used with an onprem-aws cluster. 

Adds KubernetesCluster tag to enable aws Cloud Provider, 

closes #92 