### PR TITLE
Fix dcos-launch library and sample_configs

### DIFF
--- a/dcos_launch/platforms/__init__.py
+++ b/dcos_launch/platforms/__init__.py
@@ -1,0 +1,1 @@
+# Makes it a module.

--- a/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-with-helper.yaml
@@ -16,6 +16,7 @@ dcos_config:
     - 8.8.8.8
   dns_search: mesos
   master_discovery: static
+  exhibitor_storage_backend: static
 num_masters: 1
 num_private_agents: 1
 num_public_agents: 1

--- a/dcos_launch/sample_configs/aws-onprem.yaml
+++ b/dcos_launch/sample_configs/aws-onprem.yaml
@@ -16,6 +16,7 @@ dcos_config:
         - 8.8.8.8
     dns_search: mesos
     master_discovery: static
+    exhibitor_storage_backend: static
 num_masters: 3
 num_private_agents: 2
 num_public_agents: 1


### PR DESCRIPTION
1. Make platforms package. This is required when using dcos_launch as a pip installed package.

2. Fix Sample Configs for AWS Onprem installation.