### PR TITLE
add UPDATE_COMPLETE to transition states in the delete method for AWS clusters

### DIFF
--- a/dcos_launch/aws.py
+++ b/dcos_launch/aws.py
@@ -89,7 +89,7 @@ class DcosCloudformationLauncher(dcos_launch.util.AbstractLauncher):
             # must wait for stack to be deleted before removing
             # network resources on which it depends
             self.stack.wait_for_complete(
-                transition_states=['CREATE_COMPLETE', 'DELETE_IN_PROGRESS'],
+                transition_states=['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'DELETE_IN_PROGRESS'],
                 end_states=['DELETE_COMPLETE'])
             self.delete_temp_resources(self.config['temp_resources'])
 


### PR DESCRIPTION
Fixes [QUALITY-2025](https://jira.mesosphere.com/browse/QUALITY-2025) `dcos-launch delete fails with "StackStatus changed unexpectedly to: UPDATE_COMPLETE"`

`dcos-launch wait`'s end states are `CREATE_COMPLETE` and `UPDATE_COMPLETE`, so to follow that, the transition states for `dcos-launch delete` (which is called after `wait`) should include `UPDATE_COMPLETE`. 

Even if at the final state of `wait` the stack's state is `CREATE_COMPLETE`, the `dcos-launch-bot` service runs garbage collection, which includes updating tags on clusters. See https://github.com/mesosphere/dcos-launch-bot/blob/4df5d5e4137ff1a91289dc9225c803511fb0fa9f/dcos_launch_bot/monitor.py#L85 This happens periodically every 30 seconds, so stacks should be updated between the time that the cluster comes up and the tests are run. 