### PR TITLE
Open Mesos and Marathon ports

### DIFF
--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -164,6 +164,30 @@
           },
           {
             "IpProtocol": "tcp",
+            "FromPort": "5050",
+            "ToPort": "5050",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8080",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8443",
+            "ToPort": "8443",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
             "FromPort": "61001",
             "ToPort": "61001",
             "CidrIp": {

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -164,6 +164,30 @@
           },
           {
             "IpProtocol": "tcp",
+            "FromPort": "5050",
+            "ToPort": "5050",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8080",
+            "ToPort": "8080",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "8443",
+            "ToPort": "8443",
+            "CidrIp": {
+              "Ref": "AllowAccessFrom"
+            }
+          },
+          {
+            "IpProtocol": "tcp",
             "FromPort": "61001",
             "ToPort": "61001",
             "CidrIp": {


### PR DESCRIPTION
In order to first-class the resilience tests direct access to Mesos and Marathon instances is desired. This is necessary at this point until appropriate DC/OS checks are in place that can be accessed over SSH.

I am aware of the security risk of this change. The resilience tests specify `admin_location` to be the IP range of the machine executing the tests. However other tests using DC/OS launch might not have such restrictions and for them it may very well be dangerous to expose those ports to the public.

Right now I'm modifying the template in a separate branch in e2e every time DC/OS launch is bumped.