### PR TITLE
Targeted Retrying on CF Stack wait function

### DIFF
--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -298,7 +298,9 @@ class CfStack:
         """
         log.info('Waiting for stack operation to complete')
 
+        # wait for 60 seconds before retry
         @retrying.retry(wait_fixed=60 * 1000,
+                        retry_on_result=lambda result: result is None,
                         retry_on_exception=lambda ex: False)
         def wait_loop():
             self.refresh_stack()

--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -291,26 +291,30 @@ class CfStack:
         UPDATE_COMPLETE, UPDATE_ROLLBACK_IN_PROGRESS
         UPDATE_ROLLBACK_FAILED, UPDATE_ROLLBACK_COMPLETE
         UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
+
         :param transition_states: as long as the current state is in one of these, the wait continues
         :param end_states: when the current state becomes one of these, the wait stops as the operation completed
+
         """
         log.info('Waiting for stack operation to complete')
 
         @retrying.retry(wait_fixed=60 * 1000,
-                        retry_on_result=lambda res: not isinstance(res, str),
                         retry_on_exception=lambda ex: False)
         def wait_loop():
+            self.refresh_stack()
             stack_status = self.get_status()
-            log.info('stack status: ' + stack_status)
+            log.info("Stack status {status}. Continuing to wait... ".format(status=stack_status))
+
             if stack_status in end_states:
                 return stack_status
+
             if stack_status not in transition_states:
                 for event in self.get_stack_events():
                     log.error('Stack Events: {}'.format(event))
                 raise Exception('StackStatus changed unexpectedly to: {}'.format(stack_status))
-            log.info('Continuing to wait...')
 
         status = wait_loop()
+
         return status
 
     @retry_boto_rate_limits
@@ -333,9 +337,14 @@ class CfStack:
                                  Tags=cf_tags)
 
     @retry_boto_rate_limits
-    def get_status(self):
+    def refresh_stack(self):
         # we need to refresh the stack to get the latest info
         self.stack = self.boto_wrapper.resource('cloudformation').Stack(self.name)
+        return self.stack
+
+    @retry_boto_rate_limits
+    def get_status(self):
+        self.refresh_stack()
         return self.stack.stack_status
 
     def get_parameter(self, param):
@@ -383,7 +392,9 @@ class DcosCfStack(CleanupS3BucketMixin):
             'AdminLocation': admin_location,
             'PublicSlaveInstanceCount': str(public_agents),
             'SlaveInstanceCount': str(private_agents)}
+
         boto_wrapper.create_stack(stack_name, parameters, template_url=template_url)
+
         return cls(stack_name, boto_wrapper), SSH_INFO['coreos']
 
     @property


### PR DESCRIPTION
This is *mostly* a no-op change.

The important change is removal of this statement.

```
retry_on_result=lambda res: not isinstance(res, str),
```

This was just confusing. We retry only an exception and we return when our stack_status value is one of end-states, which should be string.

When I was looking at this https://jira.mesosphere.com/browse/QUALITY-1975
And specifically, an error like this - 

https://teamcity.mesosphere.io/viewLog.html?buildId=1052330&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsCloudFormationSimple&tab=buildLog#_state=1316!

he troubleshooting didn't give much information (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#basic-ts-guide) 

We already are a) Taking in account the rate limits, so this will be probably give more information once deployed.

* Also, we will simply need to prune the s3 buckets out of band.
