### PR TITLE
Sync dcos-launch with latest acs-engine updates

### DIFF
--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -178,18 +178,9 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
         if windows_image_source_url:
             acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
-        linux_repository_url = self.config.get('dcos_linux_repository_url')
-        linux_cluster_package_list_id = self.config.get('dcos_linux_cluster_package_list_id')
-        provider_package_id = self.config.get('provider_package_id')
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:
             self.config['template_parameters']['dcosBootstrapURL'] = linux_bs_url
-        if linux_repository_url:
-            self.config['template_parameters']['dcosRepositoryURL'] = linux_repository_url
-        if linux_cluster_package_list_id:
-            self.config['template_parameters']['dcosClusterPackageListID'] = linux_cluster_package_list_id
-        if provider_package_id:
-            self.config['template_parameters']['dcosProviderPackageID'] = provider_package_id
         self.azure_wrapper.deploy_template_to_new_resource_group(
             self.config.get('template_url'),
             self.config['deployment_name'],

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -540,15 +540,6 @@ ACS_ENGINE_SCHEMA = {
     'windows_image_source_url': {
         'type': 'string',
         'required': False},
-    'dcos_linux_repository_url': {
-        'type': 'string',
-        'required': False},
-    'dcos_linux_cluster_package_list_id': {
-        'type': 'string',
-        'required': False},
-    'provider_package_id': {
-        'type': 'string',
-        'required': False},
     'ssh_user': {
         'type': 'string',
         'required': True,


### PR DESCRIPTION
Since the bootstrap node support in acs-engine (https://github.com/Azure/acs-engine/pull/2825), these parameters are not needed anymore.