### PR TITLE
get latest ACS engine version by default

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -471,11 +471,16 @@ ACS_ENGINE_SCHEMA = {
     'deployment_name': {
         'type': 'string',
         'required': True},
+    'acs_version': {
+        'type': 'string',
+        'default_setter': lambda doc: get_latest_github_release('Azure', 'acs-engine', '0.16.2')
+    },
     'acs_engine_tarball_url': {
         'type': 'string',
-        'required': True,
-        'default': get_platform_dependent_url(
-            'https://github.com/Azure/acs-engine/releases/download/v0.12.1/acs-engine-v0.12.1-{}-amd64.tar.gz',
+        'readonly': True,
+        'default_setter': lambda doc: get_platform_dependent_url(
+            'https://github.com/Azure/acs-engine/releases/download/v{0}/acs-engine-v{0}-{1}-amd64.tar.gz'.
+                format(doc['acs_version'], '{}'),
             'No ACS-Engine distribution for {}'.format(sys.platform))},
     'acs_template_filename': {
         'type': 'string',
@@ -627,14 +632,12 @@ def set_key_helper(platform: str, terraform_config: dict):
     raise Exception('Platform {} unrecognized'.format(platform))
 
 
-def get_latest_terraform_version(doc: dict):
-    default = '0.11.6'
+def get_latest_github_release(org: str, repo: str, default: str):
     try:
-        response = requests.get('https://api.github.com/repos/hashicorp/terraform/releases/latest')
+        response = requests.get('https://api.github.com/repos/{}/{}/releases/latest'.format(org, repo))
         return response.json()['tag_name'][1:]
     except Exception as e:
-        log.error('Failed to get latest terraform version. Defaulting to {}. Error details: {}'.format(default,
-                                                                                                       repr(e)))
+        log.error('Failed to get latest {} version. Defaulting to {}. Error details: {}'.format(repo, default, repr(e)))
         return default
 
 
@@ -644,10 +647,11 @@ TERRAFORM_COMMON_SCHEMA = {
         'default': False},
     'terraform_version': {
         'type': 'string',
-        'default_setter': get_latest_terraform_version
+        'default_setter': lambda doc: get_latest_github_release('hashicorp', 'terraform', '0.11.6')
     },
     'terraform_tarball_url': {
         'type': 'string',
+        'readonly': True,
         'default_setter': lambda doc: get_platform_dependent_url(
             'https://releases.hashicorp.com/terraform/{0}/terraform_{0}_{1}_amd64.zip'.format(doc['terraform_version'],
                                                                                               sys.platform),


### PR DESCRIPTION
acs-engine currently failing on master because acs-engine latest version isn't being used
This PR pulls latest version from github by default, just like for terraform. So a generic function was created for both