### PR TITLE
Sync dcos-launch with latest acs-engine changes

### DIFF
--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -177,6 +177,12 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
         windows_image_source_url = self.config.get('windows_image_source_url')
         if windows_image_source_url:
             acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
+        else:
+            # Use the official Azure image if a custom VHD was not specified
+            # via the windows_image_source_url config option
+            acs_engine_template["properties"]["windowsProfile"]["WindowsPublisher"] = self.config.get('windows_publisher')
+            acs_engine_template["properties"]["windowsProfile"]["WindowsOffer"] = self.config.get('windows_offer')
+            acs_engine_template["properties"]["windowsProfile"]["WindowsSku"] = self.config.get('windows_sku')
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -40,7 +40,7 @@ def generate_acs_engine_template(
         "properties": {
             "orchestratorProfile": {
                 "orchestratorType": "DCOS",
-                "orchestratorVersion": "1.11.0"
+                "orchestratorRelease": "1.11"
             },
             "masterProfile": {
                 "count": num_masters,

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -180,9 +180,12 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
         else:
             # Use the official Azure image if a custom VHD was not specified
             # via the windows_image_source_url config option
-            acs_engine_template["properties"]["windowsProfile"]["WindowsPublisher"] = self.config.get('windows_publisher')
-            acs_engine_template["properties"]["windowsProfile"]["WindowsOffer"] = self.config.get('windows_offer')
-            acs_engine_template["properties"]["windowsProfile"]["WindowsSku"] = self.config.get('windows_sku')
+            windows_publisher = self.config.get('windows_publisher')
+            windows_offer = self.config.get('windows_offer')
+            windows_sku = self.config.get('windows_sku')
+            acs_engine_template["properties"]["windowsProfile"]["WindowsPublisher"] = windows_publisher
+            acs_engine_template["properties"]["windowsProfile"]["WindowsOffer"] = windows_offer
+            acs_engine_template["properties"]["windowsProfile"]["WindowsSku"] = windows_sku
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -123,8 +123,6 @@ def run_acs_engine(acs_engine_url: str, acs_engine_template):
     cluster_name = acs_engine_template['properties']['masterProfile']['dnsPrefix']
     with open(os.path.join(tmpdir, '_output/{}/azuredeploy.json'.format(cluster_name)), 'r') as f:
         arm_template = json.load(f)
-    arm_template['variables']['agentWindowsOffer'] = 'WindowsServerSemiAnnual'
-    arm_template['variables']['agentWindowsSku'] = 'Datacenter-Core-1709-with-Containers-smalldisk'
     with open(os.path.join(tmpdir, '_output/{}/azuredeploy.parameters.json'.format(cluster_name)), 'r') as f:
         arm_template_parameters_raw = json.load(f)
     arm_template_parameters = dict()

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -31,6 +31,7 @@ def generate_acs_engine_template(
         windows_admin_user: str,
         windows_admin_password: str,
         linux_admin_user: str,
+        acs_engine_dcos_orchestrator_release: str,
         ):
     """ Generates the template provided to ACS-engine
     """
@@ -40,7 +41,7 @@ def generate_acs_engine_template(
         "properties": {
             "orchestratorProfile": {
                 "orchestratorType": "DCOS",
-                "orchestratorRelease": "1.11"
+                "orchestratorRelease": acs_engine_dcos_orchestrator_release
             },
             "masterProfile": {
                 "count": num_masters,
@@ -173,7 +174,8 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
             self.config['linux_public_vm_size'],
             self.config['windows_admin_user'],
             self.config['windows_admin_password'],
-            self.config['linux_admin_user'])
+            self.config['linux_admin_user'],
+            self.config['acs_engine_dcos_orchestrator_release'])
         windows_image_source_url = self.config.get('windows_image_source_url')
         if windows_image_source_url:
             acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -67,7 +67,7 @@ def generate_acs_engine_template(
                     "name": "linpub",
                     "count": num_linux_public_agents,
                     "vmSize": linux_public_vm_size,
-                    "osType": "linux",
+                    "osType": "Linux",
                     "dnsPrefix": "linpub" + unique_id,
                     "ports": [80, 443, 22]
                 },
@@ -75,7 +75,7 @@ def generate_acs_engine_template(
                     "name": "linpri",
                     "count": num_linux_private_agents,
                     "vmSize": linux_private_vm_size,
-                    "osType": "linux"
+                    "osType": "Linux"
                 }
             ],
             "windowsProfile": {

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -487,6 +487,9 @@ ACS_ENGINE_SCHEMA = {
     'acs_template_filename': {
         'type': 'string',
         'required': False},
+    'acs_engine_dcos_orchestrator_release': {
+        'type': 'string',
+        'default': '1.11'},
     'platform': {
         'type': 'string',
         'readonly': True,

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -542,6 +542,18 @@ ACS_ENGINE_SCHEMA = {
     'dcos_linux_bootstrap_url': {
         'type': 'string',
         'required': False},
+    'windows_publisher': {
+        'type': 'string',
+        'default': 'MicrosoftWindowsServer'
+    },
+    'windows_offer': {
+        'type': 'string',
+        'default': 'WindowsServerSemiAnnual'
+    },
+    'windows_sku': {
+        'type': 'string',
+        'default': 'Datacenter-Core-1803-with-Containers-smalldisk'
+    },
     'windows_image_source_url': {
         'type': 'string',
         'required': False},


### PR DESCRIPTION
This pull requests adds the following updates:

* Set `orchestratorRelease` instead of `orchestratorVersion`
* Add config option for acs-engine `orchestratorRelease`
* Fix capitalization for acs-engine template `osType`
* Remove hard-coded `agentWindowsOffer` and `agentWindowsSku`
* Add acs-engine configs: `windows_publisher`, `windows_offer` and `windows_sku`