### PR TITLE
Use dcos-check-runner for postflight checks

### DIFF
--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -238,30 +238,47 @@ def do_postflight(client: ssh_client.AsyncSshClient):
     """ Runs a script that will check if DC/OS is operational without needing to authenticate
     """
     postflight_script = """
-T=900
-if [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
-    for check_type in node-poststart cluster; do
-        until OUT=$(sudo /opt/mesosphere/bin/dcos-shell /opt/mesosphere/bin/dcos-diagnostics check $check_type) \
-                || [[ T -eq 0 ]]; do
-            sleep 1
-            let T=T-1
-        done
-        RETCODE=$?
-        echo $OUT
-        if [[ RETCODE -ne 0 ]]; then
-            exit $RETCODE
-        fi
-        T=900
-    done
-else
-    until OUT=$(sudo /opt/mesosphere/bin/./3dt --diag) || [[ T -eq 0 ]]; do
+function run_command_until_success() {
+    # Run $@ until it exits 0 or until it has been tried 900 times. Prints shell output and returns the status of the
+    # last attempted run.
+    cmd=$@
+    max_runs=900
+
+    runs=$max_runs
+    until out=$($cmd) || [[ runs -eq 0 ]]; do
         sleep 1
-        let T=T-1
+        let runs=runs-1
     done
+    retcode=$?
+
+    echo "$out"
+    return $retcode
+}
+
+function run_checks() {
+    # Run checks with the base command $@ until they succeed or have been tried 900 times. Prints shell output and
+    # returns the status of the last attempted check run.
+    check_cmd=$@
+
+    for check_type in node-poststart cluster; do
+        run_command_until_success $check_cmd $check_type
+        check_status=$?
+        if [[ check_status -ne 0 ]]; then
+            break
+        fi
+    done
+
+    return $check_status
+}
+
+if [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
+    # Cluster with dcos-diagnostics checks available.
+    run_checks sudo /opt/mesosphere/bin/dcos-shell /opt/mesosphere/bin/dcos-diagnostics check
     RETCODE=$?
-    for value in $OUT; do
-        echo $value
-    done
+else
+    # Older version cluster without checks.
+    run_command_until_success sudo /opt/mesosphere/bin/3dt --diag
+    RETCODE=$?
 fi
 exit $RETCODE
 """

--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -271,12 +271,16 @@ function run_checks() {
     return $check_status
 }
 
-if [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
-    # Cluster with dcos-diagnostics checks available.
+if [ -f /opt/mesosphere/bin/dcos-check-runner ]; then
+    # Cluster with dcos-check-runner available.
+    run_checks sudo /opt/mesosphere/bin/dcos-shell /opt/mesosphere/bin/dcos-check-runner check
+    RETCODE=$?
+elif [ -f /opt/mesosphere/etc/dcos-diagnostics-runner-config.json ]; then
+    # Older version cluster with dcos-diagnostics checks available.
     run_checks sudo /opt/mesosphere/bin/dcos-shell /opt/mesosphere/bin/dcos-diagnostics check
     RETCODE=$?
 else
-    # Older version cluster without checks.
+    # Even older version cluster without checks.
     run_command_until_success sudo /opt/mesosphere/bin/3dt --diag
     RETCODE=$?
 fi


### PR DESCRIPTION
## High-level description (required)

This updates the postflight script to use the dcos-check-runner added with https://github.com/dcos/dcos/pull/2921.

## Corresponding tickets (required)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3559](https://jira.mesosphere.com/browse/DCOS_OSS-3559) Update dcos-launch to use dcos-check-runner for postflight checks

## Related tickets (optional)

Other tickets related to this change

  - [DCOS_OSS-3491](https://jira.mesosphere.com/browse/DCOS_OSS-3491) Separate check runner from dcos-diagnostics

## Related PRs (optional)

Is this change going to be propagated up into dcos-integration-tests in dcos/dcos or another repo? Does this change require changes in dcos-test-utils? Link the corresponding PRs here:

https://github.com/dcos/dcos/pull/2921

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [x] **Added or updated any relevant documentation**

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

**dcos/dcos master** (checks provided by dcos-diagnostics)
  - [x] AWS Cloudformation Simple (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096234&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_Aws)
  - [x] Azure Resource Manager (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096236&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_AzureResourceManager)
  - [x] Onprem-AWS (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096238&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_OnpremAwsNew)
  - [x] Onprem-GCE (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096240&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_OnpremGce)

**dcos/dcos#2921** (checks provided by dcos-check-runner)
  - [x] AWS Cloudformation Simple (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096242&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_Aws)
  - [x] Azure Resource Manager (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096252&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_AzureResourceManager)
  - [x] Onprem-AWS (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096246&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_OnpremAwsNew)
  - [x] Onprem-GCE (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1096248&tab=buildResultsDiv&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_OnpremGce)

**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**