### PR TITLE
Fix install_prereqs: True bug

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -5,11 +5,9 @@ import os
 import sys
 import uuid
 
-import pkg_resources
 import requests
 
 import cerberus
-import dcos_launch
 import yaml
 from dcos_launch import util
 from dcos_launch.platforms import aws, gcp
@@ -108,6 +106,7 @@ def get_validated_config(user_config: dict, config_dir: str) -> dict:
     if owner:
         user_config.setdefault('tags', {'owner': owner})
     # validate against the fields common to all configs
+    user_config['config_dir'] = config_dir
     validator = LaunchValidator(COMMON_SCHEMA, config_dir=config_dir, allow_unknown=True)
     if not validator.validate(user_config):
         _raise_errors(validator)
@@ -199,6 +198,10 @@ COMMON_SCHEMA = {
             'acs-engine',
             'onprem',
             'terraform']},
+    'config_dir': {
+        'type': 'string',
+        'required': False
+    },
     'launch_config_version': {
         'type': 'integer',
         'required': True,
@@ -359,11 +362,8 @@ ONPREM_DEPLOY_COMMON_SCHEMA = {
         'validator': _validate_fault_domain_helper
     },
     'prereqs_script_filename': {
-        'coerce': 'expand_local_path',
-        'required': False,
-        'default_setter':
-            lambda doc: pkg_resources.resource_filename(dcos_launch.__name__, 'scripts/install_prereqs.sh') \
-            if doc['install_prereqs'] else ''
+        'type': 'string',
+        'default': 'unset'
     },
     'install_prereqs': {
         'type': 'boolean',

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -6,9 +6,10 @@ import shutil
 import typing
 
 import pkg_resources
+import yaml
 
 import dcos_launch
-import yaml
+from dcos_launch import config
 from dcos_launch import util
 from dcos_launch.platforms import onprem as platforms_onprem
 from dcos_test_utils import onprem
@@ -189,10 +190,17 @@ echo "{{\\"fault_domain\\":{{\\"region\\":{{\\"name\\": \\"$REGION\\"}},\\"zone\
             installer_path = platforms_onprem.prepare_bootstrap(t, self.config['installer_url'])
             complete_config, genconf_dir = self.get_completed_onprem_config()
             platforms_onprem.do_genconf(t, genconf_dir, installer_path)
+
+        prereqs_script = ''
+        if self.config['prereqs_script_filename'] == 'unset' and self.config['install_prereqs']:
+            prereqs_script = config.expand_path(
+                pkg_resources.resource_filename(dcos_launch.__name__, 'scripts/install_prereqs.sh'),
+                self.config['config_dir'])
+
         platforms_onprem.install_dcos(
             cluster,
             self.get_ssh_client(),
-            self.config['prereqs_script_filename'] if self.config['install_prereqs'] else None,
+            prereqs_script,
             complete_config['bootstrap_url'] + '/dcos_install.sh',
             self.config['onprem_install_parallelism'])
 

--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -87,6 +87,7 @@ def install_dcos(
         log.info('Installing prerequisites on cluster hosts')
         check_results(
             all_client.run_command('run', [util.read_file(prereqs_script_path)]), node_client, 'install_prereqs')
+        log.info('Prerequisites installed.')
     # download install script from boostrap host and run it
     remote_script_path = '/tmp/install_dcos.sh'
     log.info('Starting preflight')

--- a/dcos_launch/sample_configs/aws-onprem-install-prereqs.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-install-prereqs.yaml
@@ -1,0 +1,23 @@
+---
+launch_config_version: 1
+deployment_name: dcos-onprem-with-prereqs-install
+installer_url: https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh
+platform: aws
+provider: onprem
+aws_region: us-west-2
+os_name: cent-os-7
+instance_type: m4.xlarge
+install_prereqs: True
+dcos_config:
+  cluster_name: My Awesome DC/OS
+  resolvers:
+    - 8.8.4.4
+    - 8.8.8.8
+  dns_search: mesos
+  master_discovery: static
+  exhibitor_storage_backend: static
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+ssh_user: centos
+key_helper: true

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -238,6 +238,11 @@ def aws_onprem_config_path(tmpdir, ssh_key_path, mocked_aws_cfstack_bare_cluster
 
 
 @pytest.fixture
+def aws_onprem_install_prereqs_config_path(tmpdir, mocked_aws_cfstack_bare_cluster):
+    return get_temp_config_path(tmpdir, 'aws-onprem-install-prereqs.yaml')
+
+
+@pytest.fixture
 def aws_onprem_with_helper_config_path(tmpdir, mocked_aws_cfstack_bare_cluster):
     return get_temp_config_path(tmpdir, 'aws-onprem-with-helper.yaml')
 

--- a/test/test_onprem.py
+++ b/test/test_onprem.py
@@ -1,9 +1,13 @@
 import collections
 import json
+import os
 import subprocess
+
+import pkg_resources
 
 import dcos_launch
 import dcos_test_utils
+from dcos_launch import config
 from dcos_test_utils import helpers
 
 
@@ -13,6 +17,19 @@ def test_aws_onprem(check_cli_success, aws_onprem_config_path):
     assert info['ssh_private_key'] == dcos_launch.util.MOCK_SSH_KEY_DATA
     assert 'template_body' not in desc  # distracting irrelevant information
     assert 'bootstrap_host' in desc
+
+
+def test_aws_onprem_install_prereqs(check_cli_success, aws_onprem_install_prereqs_config_path):
+    info, desc = check_cli_success(aws_onprem_install_prereqs_config_path)
+    assert 'stack_id' in info
+    assert info['ssh_private_key'] == dcos_launch.util.MOCK_SSH_KEY_DATA
+    assert 'template_body' not in desc  # distracting irrelevant information
+    assert 'bootstrap_host' in desc
+    assert info['prereqs_script_filename'] == 'unset'
+    assert info['install_prereqs']
+    assert os.path.exists(config.expand_path(
+            pkg_resources.resource_filename(dcos_launch.__name__, 'scripts/install_prereqs.sh'),
+            info['config_dir']))
 
 
 def test_aws_onprem_with_helper(check_cli_success, aws_onprem_with_helper_config_path):


### PR DESCRIPTION
## High-level description (required)

Allows the use of "install_prereqs: True" config param. Previously, when specifying this parameter, dcos-launch could not find the default install_prereqs.sh script
Every time you call a dcos-launch command, the package data of the binary changes directories, as they are stored in a tmp directory every time the binary runs.

## Corresponding tickets (required)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

https://jira.mesosphere.com/browse/DCOS-35442

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

  - [ ] Onprem-AWS (link to job: )
  - [ ] Onprem-GCE (link to job: )
