### PR TITLE
Change CF template URLs to point to downloads.dcos.io.s3.amazonaws endpoint.

### DIFF
--- a/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
+++ b/dcos_launch/sample_configs/aws-cf-no-pytest.yaml
@@ -1,7 +1,7 @@
 ---
 launch_config_version: 1
 deployment_name: This-is-a-test-stack
-template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
+template_url: https://downloads.dcos.io.s3.amazonaws.com/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
 disable_rollback: true

--- a/dcos_launch/sample_configs/aws-cf-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-cf-with-helper.yaml
@@ -1,7 +1,7 @@
 ---
 launch_config_version: 1
 deployment_name: aws-cf-with-helper-test
-template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
+template_url: https://downloads.dcos.io.s3.amazonaws.com/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
 key_helper: true

--- a/dcos_launch/sample_configs/aws-cf.yaml
+++ b/dcos_launch/sample_configs/aws-cf.yaml
@@ -1,7 +1,7 @@
 ---
 launch_config_version: 1
 deployment_name: This-is-a-test-stack
-template_url: https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json
+template_url: https://downloads.dcos.io.s3.amazonaws.com/dcos/testing/master/cloudformation/single-master.cloudformation.json
 provider: aws
 aws_region: us-west-2
 template_parameters:


### PR DESCRIPTION
`https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json` returns the following error from dcos-launch:

``` DC/OS Launch encountered an error!
ProviderError: An error occurred (ValidationError) when calling the CreateStack operation: S3 error:
Unable to get the object
https://s3.amazonaws.com/downloads.dcos.io/dcos/testing/master/cloudformation/single-master.cloudformation.json 
```

This is because the endpoint was updated to point to `downloads.dcos.io.s3.amazonaws.com`