### PR TITLE
Replace acs-engine with dcos-engine

### DIFF
--- a/CONFIG_OPTIONS.md
+++ b/CONFIG_OPTIONS.md
@@ -368,14 +368,6 @@ string, optional
 
 string, optional
 
-### `dcos_linux_cluster_package_list_id`
-
-string, optional
-
-### `dcos_linux_repository_url`
-
-string, optional
-
 ### `deployment_name`
 
 string, required

--- a/CONFIG_OPTIONS.md
+++ b/CONFIG_OPTIONS.md
@@ -69,7 +69,7 @@ Which provider you will deploy a cluster to.
 * `onprem`: Uses the DC/OS bash installer to orchestrate a deployment on arbitrary hosts of a bare cluster. Requires `num_masters`, `num_private_agents`, `num_public_agents`, `installer_url`, `instance_type`, `os_name`, and `dcos_config`
 
 
-Allowed: aws, azure, acs-engine, onprem, gcp, terraform.
+Allowed: aws, azure, dcos-engine, onprem, gcp, terraform.
 
 ### `ssh_port`
 
@@ -354,11 +354,11 @@ string, required (if not set, will be set based on `os_name`)
 
 :warning: TODO: descriptions
 
-### `acs_engine_tarball_url`
+### `dcos_engine_tarball_url`
 
 string, optional
 
-Default: 'https://github.com/Azure/acs-engine/releases/download/v0.12.1/acs-engine-v0.12.1-<sys.platform>-amd64.tar.gz'
+Default: 'https://github.com/Azure/dcos-engine/releases/download/v0.1.0/dcos-engine-v0.1.0-<sys.platform>-amd64.tar.gz'
 
 ### `acs_template_filename`
 

--- a/dcos_launch/__init__.py
+++ b/dcos_launch/__init__.py
@@ -1,4 +1,4 @@
-from dcos_launch import acs_engine, arm, aws, gcp, terraform, util
+from dcos_launch import dcos_engine, arm, aws, gcp, terraform, util
 
 VERSION = '0.1.0'
 
@@ -18,8 +18,8 @@ def get_launcher(config, env=None):
     if platform == 'azure':
         if provider == 'azure':
             return arm.AzureResourceGroupLauncher(config, env=env)
-        if provider == 'acs-engine':
-            return acs_engine.ACSEngineLauncher(config, env=env)
+        if provider == 'dcos-engine':
+            return dcos_engine.DcosEngineLauncher(config, env=env)
         if provider == 'terraform':
             return terraform.AzureLauncher(config, env=env)
     if platform == 'gcp':

--- a/dcos_launch/acs_engine.py
+++ b/dcos_launch/acs_engine.py
@@ -190,6 +190,9 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
         arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
         if linux_bs_url:
             self.config['template_parameters']['dcosBootstrapURL'] = linux_bs_url
+        windows_bs_url = self.config.get('dcos_windows_bootstrap_url')
+        if windows_bs_url:
+            self.config['template_parameters']['dcosWindowsBootstrapURL'] = windows_bs_url
         self.azure_wrapper.deploy_template_to_new_resource_group(
             self.config.get('template_url'),
             self.config['deployment_name'],

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -552,6 +552,9 @@ ACS_ENGINE_SCHEMA = {
     'dcos_linux_bootstrap_url': {
         'type': 'string',
         'required': False},
+    'dcos_windows_bootstrap_url': {
+        'type': 'string',
+        'required': False},
     'windows_publisher': {
         'type': 'string',
         'default': 'MicrosoftWindowsServer'

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -119,8 +119,8 @@ def get_validated_config(user_config: dict, config_dir: str) -> dict:
         validator.schema.update(TERRAFORM_COMMON_SCHEMA)
     elif provider in ('aws', 'azure'):
         validator.schema.update(TEMPLATE_DEPLOY_COMMON_SCHEMA)
-    elif provider == 'acs-engine':
-        validator.schema.update(ACS_ENGINE_SCHEMA)
+    elif provider == 'dcos-engine':
+        validator.schema.update(DCOS_ENGINE_SCHEMA)
     else:
         raise Exception('Unknown provider!: {}'.format(provider))
 
@@ -199,7 +199,7 @@ COMMON_SCHEMA = {
         'allowed': [
             'aws',
             'azure',
-            'acs-engine',
+            'dcos-engine',
             'onprem',
             'terraform']},
     'config_dir': {
@@ -480,24 +480,24 @@ def get_platform_dependent_url(url_to_format: str, error_msg: str) -> str:
         raise Exception(error_msg)
 
 
-ACS_ENGINE_SCHEMA = {
+DCOS_ENGINE_SCHEMA = {
     'deployment_name': {
         'type': 'string',
         'required': True},
-    'acs_version': {
+    'dcos_engine_version': {
         'type': 'string',
-        'default_setter': lambda doc: get_latest_github_release('Azure', 'acs-engine', '0.16.2')
+        'default_setter': lambda doc: get_latest_github_release('Azure', 'dcos-engine', '0.2.0')
     },
-    'acs_engine_tarball_url': {
+    'dcos_engine_tarball_url': {
         'type': 'string',
         'default_setter': lambda doc: get_platform_dependent_url(
-            'https://github.com/Azure/acs-engine/releases/download/v{0}/acs-engine-v{0}-{1}-amd64.tar.gz'.
-                format(doc['acs_version'], '{}'),
-            'No ACS-Engine distribution for {}'.format(sys.platform))},
+            'https://github.com/Azure/dcos-engine/releases/download/v{0}/dcos-engine-v{0}-{1}-amd64.tar.gz'.
+                format(doc['dcos_engine_version'], '{}'),
+            'No DCOS-Engine distribution for {}'.format(sys.platform))},
     'acs_template_filename': {
         'type': 'string',
         'required': False},
-    'acs_engine_dcos_orchestrator_release': {
+    'dcos_engine_orchestrator_release': {
         'type': 'string',
         'default': '1.11'},
     'platform': {

--- a/dcos_launch/dcos_engine.py
+++ b/dcos_launch/dcos_engine.py
@@ -16,7 +16,7 @@ import dcos_launch.util
 log = logging.getLogger(__name__)
 
 
-def generate_acs_engine_template(
+def generate_dcos_engine_template(
         linux_ssh_public_key: str,
         num_masters: int,
         master_vm_size: str,
@@ -31,9 +31,9 @@ def generate_acs_engine_template(
         windows_admin_user: str,
         windows_admin_password: str,
         linux_admin_user: str,
-        acs_engine_dcos_orchestrator_release: str,
+        dcos_engine_orchestrator_release: str,
         ):
-    """ Generates the template provided to ACS-engine
+    """ Generates the template provided to dcos-engine
     """
     unique_id = str(uuid.uuid4())[:8] + 'dcos'
     template = {
@@ -41,7 +41,7 @@ def generate_acs_engine_template(
         "properties": {
             "orchestratorProfile": {
                 "orchestratorType": "DCOS",
-                "orchestratorRelease": acs_engine_dcos_orchestrator_release
+                "orchestratorRelease": dcos_engine_orchestrator_release
             },
             "masterProfile": {
                 "count": num_masters,
@@ -97,30 +97,30 @@ def generate_acs_engine_template(
     return template
 
 
-def run_acs_engine(acs_engine_url: str, acs_engine_template):
-    """ Runs the ACS engine
+def run_dcos_engine(dcos_engine_url: str, dcos_engine_template):
+    """ Runs the dcos-engine
     """
     tmpdir = tempfile.mkdtemp()
-    # pull down acs engine in temp dir
+    # pull down dcos engine in temp dir
     download_path = os.path.join(tmpdir, 'download.tar.gz')
     with open(download_path, 'wb') as f:
-        r = requests.get(acs_engine_url)
+        r = requests.get(dcos_engine_url)
         for chunk in r.iter_content(1024):
             f.write(chunk)
     extract_path = os.path.join(tmpdir, 'extract')
     with tarfile.open(download_path) as tar:
         tar.extractall(path=extract_path)
-    extracted_name = acs_engine_url.split('/')[-1].rstrip('.tar.gz')
-    acs_engine_bin_path = os.path.join(extract_path, extracted_name, 'acs-engine')
+    extracted_name = dcos_engine_url.split('/')[-1].rstrip('.tar.gz')
+    dcos_engine_bin_path = os.path.join(extract_path, extracted_name, 'dcos-engine')
     # inject parameters into the JSON (keyhelper, agent definitions)
     acs_template_path = os.path.join(tmpdir, 'acs_template.json')
     with open(acs_template_path, 'w') as f:
-        json.dump(acs_engine_template, f)
+        json.dump(dcos_engine_template, f)
     # run acs vs template
-    cmd = [acs_engine_bin_path, 'generate', acs_template_path]
+    cmd = [dcos_engine_bin_path, 'generate', acs_template_path]
     subprocess.check_call(cmd, cwd=tmpdir)
 
-    cluster_name = acs_engine_template['properties']['masterProfile']['dnsPrefix']
+    cluster_name = dcos_engine_template['properties']['masterProfile']['dnsPrefix']
     with open(os.path.join(tmpdir, '_output/{}/azuredeploy.json'.format(cluster_name)), 'r') as f:
         arm_template = json.load(f)
     with open(os.path.join(tmpdir, '_output/{}/azuredeploy.parameters.json'.format(cluster_name)), 'r') as f:
@@ -131,7 +131,7 @@ def run_acs_engine(acs_engine_url: str, acs_engine_template):
     return arm_template, arm_template_parameters
 
 
-class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
+class DcosEngineLauncher(dcos_launch.util.AbstractLauncher):
     def __init__(self, config: dict, env=None):
         if env is None:
             azure_subscription_id = dcos_launch.util.set_from_env('AZURE_SUBSCRIPTION_ID')
@@ -158,7 +158,7 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
             self.config.update({
                 'ssh_private_key': private_key.decode(),
                 'ssh_public_key': public_key.decode()})
-        acs_engine_template = generate_acs_engine_template(
+        dcos_engine_template = generate_dcos_engine_template(
             self.config['ssh_public_key'],
             self.config['num_masters'],
             self.config['master_vm_size'],
@@ -173,21 +173,21 @@ class ACSEngineLauncher(dcos_launch.util.AbstractLauncher):
             self.config['windows_admin_user'],
             self.config['windows_admin_password'],
             self.config['linux_admin_user'],
-            self.config['acs_engine_dcos_orchestrator_release'])
+            self.config['dcos_engine_orchestrator_release'])
         windows_image_source_url = self.config.get('windows_image_source_url')
         if windows_image_source_url:
-            acs_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
+            dcos_engine_template["properties"]["windowsProfile"]["WindowsImageSourceUrl"] = windows_image_source_url
         else:
             # Use the official Azure image if a custom VHD was not specified
             # via the windows_image_source_url config option
             windows_publisher = self.config.get('windows_publisher')
             windows_offer = self.config.get('windows_offer')
             windows_sku = self.config.get('windows_sku')
-            acs_engine_template["properties"]["windowsProfile"]["WindowsPublisher"] = windows_publisher
-            acs_engine_template["properties"]["windowsProfile"]["WindowsOffer"] = windows_offer
-            acs_engine_template["properties"]["windowsProfile"]["WindowsSku"] = windows_sku
+            dcos_engine_template["properties"]["windowsProfile"]["WindowsPublisher"] = windows_publisher
+            dcos_engine_template["properties"]["windowsProfile"]["WindowsOffer"] = windows_offer
+            dcos_engine_template["properties"]["windowsProfile"]["WindowsSku"] = windows_sku
         linux_bs_url = self.config.get('dcos_linux_bootstrap_url')
-        arm_template, self.config['template_parameters'] = run_acs_engine(self.config['acs_engine_tarball_url'], acs_engine_template)  # noqa
+        arm_template, self.config['template_parameters'] = run_dcos_engine(self.config['dcos_engine_tarball_url'], dcos_engine_template)  # noqa
         if linux_bs_url:
             self.config['template_parameters']['dcosBootstrapURL'] = linux_bs_url
         windows_bs_url = self.config.get('dcos_windows_bootstrap_url')


### PR DESCRIPTION
## High-level description

This pull request replaces the [acs-engine](https://github.com/azure/acs-engine) backend with the [dcos-engine](https://github.com/Azure/dcos-engine) backend. This is done because DC/OS support is becoming obsolete in acs-engine.

DCOS-Engine is a fork of acs-engine focused only on DC/OS support. It can be used to deploy hybrid clusters of DC/OS, and for now, it is backwards compatible with acs-engine. But in the future the two projects will diverge and they will not be compatible anymore.

## Checklist for the PR

  - [x] Rename `acs-engine` to `dcos-engine`
  - [x] Clean-up `CONFIG_OPTIONS.md` doc
  - [x] Add custom Windows bootstrap URL config option