### PR TITLE
Fix master_nics implementation for HybridDcosAzureResourceGroup

### DIFF
--- a/dcos_launch/platforms/arm.py
+++ b/dcos_launch/platforms/arm.py
@@ -333,12 +333,13 @@ class DcosAzureResourceGroup:
 class HybridDcosAzureResourceGroup(DcosAzureResourceGroup):
     @property
     def master_nics(self):
+        master_nics = []
         for resource in self.list_resources("resourceType eq 'Microsoft.Network/networkInterfaces'"):
-            if 'bootstrap' in resource.name:
-                # Skipping the bootstrap NICs
-                continue
-            assert 'master' in resource.name, 'Expected to find master NICs, not: {}'.format(resource.name)
-            yield self.azure_wrapper.nmc.network_interfaces.get(self.group_name, resource.name)
+            if 'master' in resource.name:
+                master_nics.append(resource.name)
+        assert len(master_nics) > 0, 'Cannot find any master NICs into resource group {}'.format(self.group_name)
+        for name in master_nics:
+            yield self.azure_wrapper.nmc.network_interfaces.get(self.group_name, name)
 
     def get_master_ips(self):
         public_lb_ip = self.public_master_lb_fqdn


### PR DESCRIPTION
The old implementation didn't take into account the existence of the Windows bootstrap node.