### PR TITLE
onprem: use a specific nginx image version

### DIFF
--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -11,6 +11,8 @@ from dcos_test_utils import onprem, ssh_client
 
 log = logging.getLogger(__name__)
 
+NGINX_DOCKER_IMAGE_VERSION = 'nginx:1.15.2'
+
 
 def get_client(
         cluster: onprem.OnpremCluster,
@@ -148,7 +150,7 @@ def do_genconf(
     start_docker_service(
         ssh_tunnel,
         nginx_service_name,
-        ['--publish=80:80', '--volume=' + volume_mount, 'nginx'])
+        ['--publish=80:80', '--volume=' + volume_mount, NGINX_DOCKER_IMAGE_VERSION])
 
 
 def curl(download_url: str, out_path: str) -> list:


### PR DESCRIPTION
We weren't able to deploy clusters, dcos-launch was failing when running nginx with the following error: 
```
Unable to find image 'nginx:latest' locally
latest: Pulling from library/nginx
/run/torcx/bin/docker: no supported platform found in manifest list.
See '/run/torcx/bin/docker run --help'.
Traceback (most recent call last):
  File "/usr/local/bin/dcos-launch", line 11, in <module>
    load_entry_point('dcos-launch', 'console_scripts', 'dcos-launch')()
  File "/dcos-launch/dcos_launch/cli.py", line 105, in main
    return do_main(args)
  File "/dcos-launch/dcos_launch/cli.py", line 71, in do_main
    launcher.install_dcos()
  File "/dcos-launch/dcos_launch/onprem.py", line 192, in install_dcos
    platforms_onprem.do_genconf(t, genconf_dir, installer_path)
  File "/dcos-launch/dcos_launch/platforms/onprem.py", line 149, in do_genconf
    ['--publish=80:80', '--volume=' + volume_mount, 'nginx'])
  File "/dcos-launch/dcos_launch/platforms/onprem.py", line 181, in start_docker_service
    ['sudo', 'docker', 'run', '--name', docker_name, '--detach=true'] + docker_args)
  File "/usr/local/lib/python3.5/dist-packages/dcos_test_utils/ssh_client.py", line 56, in command
    return subprocess.check_output(run_cmd, **kwargs)
  File "/usr/lib/python3.5/subprocess.py", line 316, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.5/subprocess.py", line 398, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['ssh', '-p', '22', '-oConnectTimeout=10', '-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null', '-oLogLevel=ERROR', '-oBatchMode=yes', '-oPasswordAuthentication=no', '-oControlPath=/tmp/tmp6gbk5wlh', '-oControlMaster=auto', 'core@35.199.154.154', 'sudo', 'docker', 'run', '--name', 'dcos-bootstrap-nginx', '--detach=true', '--publish=80:80', '--volume=/home/core/genconf/serve:/usr/share/nginx/html', 'nginx']' returned non-zero exit status 125
mke/make/dcos-launch.mk:108: recipe for target 'launch-dcos' failed
make: *** [launch-dcos] Error 1
```

`nginx:latest` docker image is broken as well as `nginx:1.15.3` which corresponds with the latest version. We should generally use a specific version.

related links to the issue: 
- http://hg.nginx.org/nginx/
- https://github.com/nginxinc/docker-nginx/issues/230#issuecomment-416888989