### PR TITLE
Allow for setting minCpuPlatform in GCP.

### DIFF
--- a/CONFIG_OPTIONS.md
+++ b/CONFIG_OPTIONS.md
@@ -546,6 +546,12 @@ boolean, optional
 
 Default: False
 
+### `min_cpu_platform`
+
+string, optional
+
+Allows for defining the minimum [CPU platform](https://cloud.google.com/compute/docs/cpu-platforms) to use.
+
 ## Terraform params
 
 ### `dcos-enterprise`

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -643,6 +643,9 @@ GCP_ONPREM_SCHEMA = {
         'type': 'boolean',
         'required': False,
         'default': False},
+    'min_cpu_platform': {
+        'type': 'string',
+        'required': False},
 }
 
 

--- a/dcos_launch/gcp.py
+++ b/dcos_launch/gcp.py
@@ -72,6 +72,7 @@ class OnPremLauncher(onprem.AbstractOnpremLauncher):
             self.config['ssh_public_key'],
             self.config['disable_updates'],
             self.config['use_preemptible_vms'],
+            min_cpu_platform=self.config.get('min_cpu_platform'),
             tags=self.config.get('tags'))
         return self.config
 

--- a/dcos_launch/platforms/gcp.py
+++ b/dcos_launch/platforms/gcp.py
@@ -388,6 +388,7 @@ class BareClusterDeployment(Deployment):
             ssh_public_key: str,
             disable_updates: bool,
             use_preemptible_vms: bool,
+            min_cpu_platform: str,
             tags: dict=None):
 
         deployment = cls(gcp_wrapper, name, zone)
@@ -435,6 +436,10 @@ class BareClusterDeployment(Deployment):
                 'value': IGNITION_CONFIG
             }
             deployment_config['resources'][1]['properties']['properties']['metadata']['items'].append(user_data)
+
+        # set minCpuPlatform if one has been defined
+        if min_cpu_platform:
+            deployment_config['resources'][1]['properties']['properties']['minCpuPlatform'] = min_cpu_platform
 
         gcp_wrapper.create_deployment(name, deployment_config, tags=tags)
         return deployment


### PR DESCRIPTION
## High-level description (required)

To launch GCP instances with more than 64 CPUs or 445GB RAM, one must specify `Intel Skylake` as the (minimum) CPU platform. This PR adds support for optionally choosing a minimum CPU platform. This is useful, for instance, when launching big clusters for scale testing.

## Corresponding tickets (required)

N/A

## Related tickets (optional)

N/A

## Related PRs (optional)

N/A

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A
  - [X] **Added or updated any relevant documentation**

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

  - [ ] AWS Cloudformation Simple (link to job: )
  - [ ] Azure Resource Manager (link to job: )
  - [ ] Onprem-AWS (link to job: )
  - [x] Onprem-GCE (link to job: )

**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs should have two approved [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
