### PR TITLE
Update run_centos74_prereqs.sh

### DIFF
--- a/dcos_launch/sample_configs/azure-with-helper.yaml
+++ b/dcos_launch/sample_configs/azure-with-helper.yaml
@@ -13,6 +13,6 @@ template_parameters:
   agentCount: 1
   nameSuffix: 12345
   enableVMDiagnostics: false
-  oauthEnabled: "true"
+  oauthEnabled: "true" # Azure specifically expects the boolean value for this field as a string
 ssh_user: dcos
 

--- a/dcos_launch/sample_configs/azure.yaml
+++ b/dcos_launch/sample_configs/azure.yaml
@@ -11,7 +11,7 @@ template_parameters:
     masterEndpointDNSNamePrefix: testing-foo-bar
     agentEndpointDNSNamePrefix: testing-baz-qux
     agentCount: 4
-    oauthEnabled: "false"
+    oauthEnabled: "false" # Azure specifically expects the boolean value for this field as a string
     nameSuffix: 12435
 tags:
     expiration: 2weeks

--- a/dcos_launch/scripts/run_centos74_prereqs.sh
+++ b/dcos_launch/scripts/run_centos74_prereqs.sh
@@ -6,12 +6,17 @@ sudo yum install -y yum-utils \
   lvm2
 
 sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+# Docker 17.05 is an edge release
 sudo yum-config-manager --enable docker-ce-edge
 
+# Docker 17.05 has a separate package for SELinux
 sudo yum install -y --setopt=obsoletes=0 \
   docker-ce-17.05.0.ce-1.el7.centos \
   docker-ce-selinux-17.05.0.ce-1.el7.centos
 
+# Previously, when using Docker Engine, we would use the overlay storage driver configured in /etc/systemd/system/docker.service.d/override.conf
+# Now that we are using a Docker CE release, the recommended storage driver is overlay2 and configured in /etc/docker/daemon.json
+# read more here: https://docs.docker.com/storage/storagedriver/overlayfs-driver/
 sudo tee /etc/docker/daemon.json <<- EOF
 {
   "storage-driver": "overlay2"

--- a/dcos_launch/scripts/run_centos74_prereqs.sh
+++ b/dcos_launch/scripts/run_centos74_prereqs.sh
@@ -1,4 +1,4 @@
-sudo setenforce 0
+sudo setenforce 1
 sudo bash -c 'echo -e "nameserver 8.8.8.8\n" >> /etc/resolv.conf'
 
 sudo yum install -y yum-utils \
@@ -8,16 +8,15 @@ sudo yum install -y yum-utils \
 sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 sudo yum-config-manager --enable docker-ce-edge
 
-sudo mkdir -p /etc/systemd/system/docker.service.d
-sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker daemon --storage-driver=overlay
-EOF
-
 sudo yum install -y --setopt=obsoletes=0 \
   docker-ce-17.05.0.ce-1.el7.centos \
   docker-ce-selinux-17.05.0.ce-1.el7.centos
+
+sudo tee /etc/docker/daemon.json <<- EOF
+{
+  "storage-driver": "overlay2"
+}
+EOF
 
 sudo systemctl start docker
 sudo systemctl enable docker


### PR DESCRIPTION
This is invalid configuration for Docker 17.05 for SELinux:
sudo mkdir -p /etc/systemd/system/docker.service.d
sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
[Service]
ExecStart=
ExecStart=/usr/bin/docker daemon --storage-driver=overlay
EOF

overlay must be configured differently with /etc/docker/daemon.json