### PR TITLE
Add dcos_cli_version config option

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -207,8 +207,10 @@ COMMON_SCHEMA = {
             'terraform']},
     'config_dir': {
         'type': 'string',
-        'required': False
-    },
+        'required': False},
+    'dcos_cli_version': {
+        'type': 'float',
+        'default': 1.12},
     'launch_config_version': {
         'type': 'integer',
         'required': True,

--- a/dcos_launch/util.py
+++ b/dcos_launch/util.py
@@ -131,6 +131,9 @@ class AbstractLauncher(metaclass=abc.ABCMeta):
         # populate minimal env if not already set. Note: use private IPs as this test is from
         # within the cluster
         # required for 1.8
+        env_dict['DCOS_CLI_URL'] = 'https://downloads.dcos.io/cli/testing/binaries/dcos/linux/x86-64/master/dcos' if \
+            self.config['dcos_cli_version'] == 'master' else \
+            'https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-{}/dcos'.format(self.config['dcos_cli_version'])
         if 'DNS_SEARCH' not in env_dict:
             env_dict['DNS_SEARCH'] = 'false'
         if 'DCOS_PROVIDER' not in env_dict:


### PR DESCRIPTION
By default, dcos-test-utils will use 1.11 dcos cli, which will cause some tests to fail. So we are now passing an env var to specify the version we want.