### PR TITLE
run_centos74_prereqs.sh: switch from ntpd to chronyd for faster initial sync

### DIFF
--- a/dcos_launch/scripts/run_centos74_prereqs.sh
+++ b/dcos_launch/scripts/run_centos74_prereqs.sh
@@ -28,10 +28,9 @@ sudo yum install -y unzip
 sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed
-


### PR DESCRIPTION
## High-level description (required)

What features does this change enable? / What bugs does this change fix?

The `ntpd` tool has unfortunate initialization semantics. On a new EC2 instance it can take 15+mins to perform the initial sync. This is likely due to the following:


> The ntpd behavior at startup depends on whether the frequency file, usually ntp.drift, exists. This file contains the latest estimate of clock frequency error. When the ntpd is started and the file does not exist, the ntpd enters a special mode designed to quickly adapt to the particular system clock oscillator time and frequency error. This takes approximately 15 minutes, after which the time and frequency are set to nominal values and the ntpd enters normal mode, where the time and frequency are continuously tracked relative to the server.

~ https://linux.die.net/man/8/ntpd

This PR switches from ntpd to chronyd. In my manual test I observed that NTP was sync'ed by the time DC/OS finished installing when using chronyd, as opposed to several minutes using ntpd.

The reason this is especially important is that most (all?) the DC/OS components wait for time synchronization before starting which means that if ntpd takes 15 minutes to synchronize time, DC/OS clusters take 15mins longer to launch.

#205 # Corresponding tickets (required)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46159](https://jira.mesosphere.com/browse/DCOS-46159) improve initial time synchronization on AWS clusters


## Related tickets (optional)

Other tickets related to this change

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related PRs (optional)

Is this change going to be propagated up into dcos-integration-tests in dcos/dcos or another repo? Does this change require changes in dcos-test-utils? Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] **Added or updated any relevant documentation**

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

  - [ ] AWS Cloudformation Simple (link to job: )
  - [ ] Azure Resource Manager (link to job: )
  - [ ] Onprem-AWS (link to job: )
  - [ ] Onprem-GCE (link to job: )

**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs should have two approved [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
