### PR TITLE
Apply dcos_version value coercion with normalization

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -109,6 +109,7 @@ def get_validated_config(user_config: dict, config_dir: str) -> dict:
     # validate against the fields common to all configs
     user_config['config_dir'] = config_dir
     validator = LaunchValidator(COMMON_SCHEMA, config_dir=config_dir, allow_unknown=True)
+    user_config['dcos_version'] = validator.normalized(user_config)['dcos_version']
     if not validator.validate(user_config):
         _raise_errors(validator)
 

--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -109,7 +109,8 @@ def get_validated_config(user_config: dict, config_dir: str) -> dict:
     # validate against the fields common to all configs
     user_config['config_dir'] = config_dir
     validator = LaunchValidator(COMMON_SCHEMA, config_dir=config_dir, allow_unknown=True)
-    user_config['dcos_version'] = validator.normalized(user_config)['dcos_version']
+    if 'dcos_version' in user_config:
+        user_config['dcos_version'] = validator.normalized(user_config)['dcos_version']
     if not validator.validate(user_config):
         _raise_errors(validator)
 

--- a/dcos_launch/sample_configs/aws-onprem-enterprise-with-helper.yaml
+++ b/dcos_launch/sample_configs/aws-onprem-enterprise-with-helper.yaml
@@ -1,0 +1,24 @@
+---
+launch_config_version: 1
+deployment_name: dcos-onprem-with-new-stack
+installer_url: https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh
+platform: aws
+provider: onprem
+aws_region: us-west-2
+os_name: cent-os-7-dcos-prereqs
+instance_type: m4.xlarge
+bootstrap_instance_type: m4.xlarge
+dcos_config:
+  cluster_name: My Awesome DC/OS
+  resolvers:
+    - 8.8.4.4
+    - 8.8.8.8
+  dns_search: mesos
+  master_discovery: static
+  exhibitor_storage_backend: static
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+ssh_user: centos
+key_helper: true
+dcos_version: 1.12

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -253,6 +253,11 @@ def aws_onprem_with_extra_iam_config_path(tmpdir, mocked_aws_cfstack_bare_cluste
 
 
 @pytest.fixture
+def aws_onprem_enterprise_config_path(tmpdir, mocked_aws_cfstack_bare_cluster):
+    return get_temp_config_path(tmpdir, 'aws-onprem-enterprise-with-helper.yaml')
+
+
+@pytest.fixture
 def mock_genconf_dir(tmpdir):
     """ For testing genconf_dir and providing onprem configuration via a local
         genconf dir. Similarly, the DC/OS config can be provided by a 'dcos_config' field

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -80,6 +80,9 @@ class TestAwsOnprem:
     def test_basic(self, aws_onprem_config_path):
         get_validated_config_from_path(aws_onprem_config_path)
 
+    def test_enterprise(self, aws_onprem_enterprise_config_path):
+        get_validated_config_from_path(aws_onprem_enterprise_config_path)
+
     def test_with_key_helper(self, aws_onprem_with_helper_config_path):
         get_validated_config_from_path(aws_onprem_with_helper_config_path)
 


### PR DESCRIPTION
passed here on an enterprise cluster: https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&buildTypeId=DcosIo_DcosLaunch_IntegrationTests_OnpremAwsEe&buildId=1484116

Build wrongly indicates a failure because the build failure rules are wrongly set for that TeamCity config