### PR TITLE
pin requests-oauthlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ py
 pytest
 pyyaml
 requests
+requests-oauthlib==0.8.0
 retrying
 tox

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'pytest',
         'pyyaml',
         'requests',
+        'requests-oauthlib==0.8.0',
         'retrying'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fixes the issue where the azure client cannot authenticate (underlying issue in msrestazure package)

issue example:
https://teamcity.mesosphere.io/viewLog.html?tab=buildLog&buildTypeId=DcOs_Open_Test_IntegrationTest_AzureArmCredsUpdateTest&buildId=1581695&_focus=427#_state=427