### PR TITLE
Update the Availablity Zone List.

### DIFF
--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -5,6 +5,10 @@
     "SubnetConfig" : {
       "VPC"     : { "CIDR" : "10.10.0.0/16" },
       "Public"  : { "CIDR" : "10.10.0.0/24" }
+    },
+    "RegionMap" : {
+      "us-east-1" : { "AZ" : "us-east-1a" },
+      "us-west-2" : { "AZ" : "us-west-2a" }
     }
   },
   "Parameters": {
@@ -76,7 +80,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
-        "AvailabilityZones": [ "us-west-2a", "us-west-2b", "us-west-2c"],
+        "AvailabilityZones": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -76,6 +76,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
+        "AvailabilityZones": [ "us-west-2a", "us-west-2b", "us-west-2c"],
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [

--- a/dcos_launch/templates/vpc-cluster-template.json
+++ b/dcos_launch/templates/vpc-cluster-template.json
@@ -80,7 +80,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
-        "AvailabilityZones": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
+        "AvailabilityZone": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -5,6 +5,10 @@
     "SubnetConfig" : {
       "VPC"     : { "CIDR" : "10.10.0.0/16" },
       "Public"  : { "CIDR" : "10.10.0.0/24" }
+    },
+    "RegionMap" : {
+      "us-east-1" : { "AZ" : "us-east-1a" },
+      "us-west-2" : { "AZ" : "us-west-2a" }
     }
   },
   "Parameters": {
@@ -76,7 +80,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
-        "AvailabilityZones": [ "us-west-2a", "us-west-2b", "us-west-2c"],
+        "AvailabilityZones": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -76,6 +76,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
+        "AvailabilityZones": [ "us-west-2a", "us-west-2b", "us-west-2c"],
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [

--- a/dcos_launch/templates/vpc-ebs-only-cluster-template.json
+++ b/dcos_launch/templates/vpc-ebs-only-cluster-template.json
@@ -80,7 +80,7 @@
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
-        "AvailabilityZones": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
+        "AvailabilityZone": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AZ" ]},
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
         "Tags" : [


### PR DESCRIPTION
## High-level description (required)

dcos-launch onprem cluster installers load these templates

```
skumaran@shannon:~/github/dcos/dcos-launch/dcos_launch$ ag vpc-cluster-template.json
platforms/aws.py
37:        template = pkg_resources.resource_string(dcos_launch.__name__, 'templates/vpc-cluster-template.json')
skumaran@shannon:~/github/dcos/dcos-launch/dcos_launch$ ag vpc-ebs-only-cluster-template.json
platforms/aws.py
35:        template = pkg_resources.resource_string(dcos_launch.__name__, 'templates/vpc-ebs-only-cluster-template.json')
skumaran@shannon:~/github/dcos/dcos-launch/dcos_launch$ 


```

The idea is to restrict the availability zones to the supported list.