### PR TITLE
Selinux patch

### DIFF
--- a/dcos_launch/config.py
+++ b/dcos_launch/config.py
@@ -298,7 +298,6 @@ ONPREM_DEPLOY_COMMON_SCHEMA = {
         'default': False},
     'enable_selinux': {
         'type': 'boolean',
-        'readonly': True,
         'default_setter': lambda doc:
             doc['auto_set_selinux'] and
             doc.get('dcos_version', '') >= '1.12' and

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -200,7 +200,7 @@ echo "{{\\"fault_domain\\":{{\\"region\\":{{\\"name\\": \\"$REGION\\"}},\\"zone\
             self.config['install_prereqs'],
             complete_config['bootstrap_url'] + '/dcos_install.sh',
             self.config['onprem_install_parallelism'],
-            self.config['enable_selinux'])
+            self.config.get('enable_selinux'))
 
     def describe(self):
         """ returns host information stored in the config as

--- a/dcos_launch/onprem.py
+++ b/dcos_launch/onprem.py
@@ -200,8 +200,7 @@ echo "{{\\"fault_domain\\":{{\\"region\\":{{\\"name\\": \\"$REGION\\"}},\\"zone\
             self.config['install_prereqs'],
             complete_config['bootstrap_url'] + '/dcos_install.sh',
             self.config['onprem_install_parallelism'],
-            self.config['enable_selinux'],
-            self.config['auto_set_selinux'])
+            self.config['enable_selinux'])
 
     def describe(self):
         """ returns host information stored in the config as

--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -8,6 +8,7 @@ import sys
 import retrying
 
 from dcos_test_utils import onprem, ssh_client
+from typing import Union
 
 log = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ def install_dcos(
         install_prereqs: bool,
         bootstrap_script_url: str,
         parallelism: int,
-        enable_selinux: bool):
+        enable_selinux: Union[bool, None]):
     """
     Args:
         cluster: cluster abstraction for handling network addresses
@@ -79,7 +80,7 @@ def install_dcos(
         prereqs_script_path: if given, this will be run before preflight on any nodes
         bootstrap_script_url: where the installation script will be pulled from (see do_genconf)
         parallelism: how many concurrent SSH tunnels to run
-        enable_selinux: attempmt to enable selinux on every node
+        enable_selinux: attempt to enable selinux on every node
     """
     # Check to make sure we can talk to the cluster
     for host in cluster.cluster_hosts:
@@ -88,8 +89,9 @@ def install_dcos(
     all_client = get_client(cluster, 'cluster_hosts', node_client, parallelism=parallelism)
 
     # enable or disable selinux depending on the config
-    setenforce = '1' if enable_selinux else '0'
-    check_results(all_client.run_command('run', ['sudo setenforce ' + setenforce]), node_client, 'Set SELinux mode')
+    if enable_selinux is not None:
+        setenforce = '1' if enable_selinux else '0'
+        check_results(all_client.run_command('run', ['sudo setenforce ' + setenforce]), node_client, 'Set SELinux mode')
 
     # install prereqs if enabled
     if install_prereqs:

--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -71,8 +71,7 @@ def install_dcos(
         install_prereqs: bool,
         bootstrap_script_url: str,
         parallelism: int,
-        enable_selinux: bool,
-        auto_set_selinux: bool):
+        enable_selinux: bool):
     """
     Args:
         cluster: cluster abstraction for handling network addresses
@@ -80,10 +79,7 @@ def install_dcos(
         prereqs_script_path: if given, this will be run before preflight on any nodes
         bootstrap_script_url: where the installation script will be pulled from (see do_genconf)
         parallelism: how many concurrent SSH tunnels to run
-        enable_selinux: whether to enable or disable SELinux on every node. This field is readonly in the config and
-            set automatically. This variable will have no effect if auto_set_selinux is False.
-        auto_set_selinux: if set to True, will attempt to enable or disable SELinux, depending on the value of the
-            enable_selinux parameter.
+        enable_selinux: attempmt to enable selinux on every node
     """
     # Check to make sure we can talk to the cluster
     for host in cluster.cluster_hosts:
@@ -92,9 +88,8 @@ def install_dcos(
     all_client = get_client(cluster, 'cluster_hosts', node_client, parallelism=parallelism)
 
     # enable or disable selinux depending on the config
-    if auto_set_selinux:
-        setenforce = '1' if enable_selinux else '0'
-        check_results(all_client.run_command('run', ['sudo setenforce ' + setenforce]), node_client, 'Set SELinux mode')
+    setenforce = '1' if enable_selinux else '0'
+    check_results(all_client.run_command('run', ['sudo setenforce ' + setenforce]), node_client, 'Set SELinux mode')
 
     # install prereqs if enabled
     if install_prereqs:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -107,7 +107,7 @@ class TestAwsOnprem:
 
         # [{config values}, expected value of enable_selinux]
         scenarios = [
-            [{}, False],
+            [{}, None],
             [{'auto_set_selinux': True}, False],
             [{'auto_set_selinux': True, 'dcos_version': '1.12'}, False],
             [{'auto_set_selinux': True, 'dcos_version': '1.10'}, False],
@@ -119,9 +119,10 @@ class TestAwsOnprem:
             [{'auto_set_selinux': True, 'dcos_version': 'master', 'installer_url':
                 'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, True],
             [{'auto_set_selinux': True, 'dcos_version': 'master', 'enable_selinux': False, 'installer_url':
-                'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
+                'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'},
+                Exception],
             [{'auto_set_selinux': False, 'dcos_version': 'master', 'installer_url':
-                'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
+                'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, None],
         ]
 
         for s in scenarios:
@@ -129,8 +130,11 @@ class TestAwsOnprem:
             with open(aws_onprem_config_path) as f:
                 config = yaml.load(f)
                 config.update(values)
-                config = get_validated_config(config, config_dir)
-                assert config['enable_selinux'] is expected_selinux
+                try:
+                    config = get_validated_config(config, config_dir)
+                    assert config.get('enable_selinux') is expected_selinux
+                except Exception:
+                    assert Exception is expected_selinux
 
 
 class TestGcpOnprem:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -111,12 +111,15 @@ class TestAwsOnprem:
             [{'auto_set_selinux': True}, False],
             [{'auto_set_selinux': True, 'dcos_version': '1.12'}, False],
             [{'auto_set_selinux': True, 'dcos_version': '1.10'}, False],
+            [{'auto_set_selinux': False, 'enable_selinux': True, 'dcos_version': '1.10'}, True],
             [{'auto_set_selinux': True, 'installer_url':
                 'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
             [{'auto_set_selinux': True, 'dcos_version': 1.11, 'installer_url':
                 'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
             [{'auto_set_selinux': True, 'dcos_version': 'master', 'installer_url':
                 'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, True],
+            [{'auto_set_selinux': True, 'dcos_version': 'master', 'enable_selinux': False, 'installer_url':
+                'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
             [{'auto_set_selinux': False, 'dcos_version': 'master', 'installer_url':
                 'https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh'}, False],
         ]


### PR DESCRIPTION
new behavior:
1) enable_selinux has no default value, in which case we do not try to enable or disable selinux. We skip that command entirely.
2) enable_selinux can be specified, but cannot be specified at the same time as auto_set_selinux option.
3) if auto_set_selinux is true, enable_selinux's value will be set automatically based on dcos version and variant