### PR TITLE
DCOS_OSS-5000 - Retry CreateKeyPair when rate limit reached.

### DIFF
--- a/dcos_launch/platforms/aws.py
+++ b/dcos_launch/platforms/aws.py
@@ -97,6 +97,8 @@ class BotoWrapper:
         region = self.region if region is None else region
         return self.session.resource(service_name=name, region_name=region)
 
+    @retry(wait_exponential_multiplier=1000, wait_exponential_max=20 * 60 * 1000,
+           retry_on_exception=retry_on_rate_limiting)
     def create_key_pair(self, key_name):
         """Returns private key of newly generated pair
         """


### PR DESCRIPTION
## High-level description (required)

This change ensures that we retry CreateKeyPair when the AWS rate limit is reached.

## Corresponding tickets (required)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5000](https://jira.mesosphere.com/browse/DCOS_OSS-5000) dcos-launch fails with RequestLimitExceeded

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A, no existing tests for API clients and change is minimal.

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

  - [x] AWS Cloudformation Simple (link to job: https://teamcity.mesosphere.io/viewQueued.html?itemId=1795468)
  - [x] Azure Resource Manager (link to job: N/A AWS-specific)
  - [x] Onprem-AWS (link to job: https://teamcity.mesosphere.io/viewQueued.html?itemId=1795470)
  - [x] Onprem-GCE (link to job: N/A AWS-specific)