### PR TITLE
Increase the curl --speed-time for the given --speed-limit to deal with Operation too Slow.

### DIFF
--- a/dcos_launch/platforms/onprem.py
+++ b/dcos_launch/platforms/onprem.py
@@ -169,7 +169,7 @@ def do_genconf(
 def curl(download_url: str, out_path: str) -> list:
     """ returns a robust curl command in list form
     """
-    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '60',
+    return ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '90',
             '--create-dirs', '-o', out_path, download_url]
 
 


### PR DESCRIPTION
## High-level description (required)

* Increase the --speed-time for the given --speed-limit from 60 seconds to 90 seconds.

This will tackle the issues such as:

> curl: (28) Operation too slow. Less than 100000 bytes/sec transferred the last 60 seconds

mentioned in  https://jira.mesosphere.com/browse/DCOS_OSS-5138 

From curl manual.

```
-Y, --speed-limit <speed>
       If a download is slower than this given speed (in bytes per second) for speed-time seconds it gets
       aborted. speed-time is set with -y and is 30 if not set.

       If this option is used several times, the last one will be used.
-y, --speed-time <time>
       If a download is slower than speed-limit bytes per second during a speed-time period, the download
       gets aborted. If speed-time is used, the default speed-limit will be 1 unless set with -Y.

       This  option  controls  transfers and thus will not affect slow connects etc. If this is a concern
       for you, try the --connect-timeout option.

       If this option is used several times, the last one will be used.

```
