### PR TITLE
Remove nogroup creation 

### DIFF
--- a/dcos_launch/scripts/install_prereqs.sh
+++ b/dcos_launch/scripts/install_prereqs.sh
@@ -171,9 +171,4 @@ EOF
   sudo systemctl enable docker
 fi
 
-if ! sudo getent group nogroup >/dev/null; then
-  echo "Creating 'nogroup' group..."
-  sudo groupadd nogroup
-fi
-
 echo "Prerequisites installed."

--- a/dcos_launch/scripts/run_centos74_prereqs.sh
+++ b/dcos_launch/scripts/run_centos74_prereqs.sh
@@ -30,6 +30,5 @@ sudo yum install -y ipset
 sudo yum install -y chrony
 sudo systemctl enable chronyd
 sudo systemctl start chronyd
-sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed


### PR DESCRIPTION
## High-level description (required)

What features does this change enable? / What bugs does this change fix?


## Corresponding tickets (required)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [COPS-5220](https://jira.mesosphere.com/browse/COPS-5220) 
  - https://github.com/dcos/dcos/pull/6166

## Related tickets (optional)

Other tickets related to this change

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related PRs (optional)

Is this change going to be propagated up into dcos-integration-tests in dcos/dcos or another repo? Does this change require changes in dcos-test-utils? Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] **Added or updated any relevant documentation**

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch&branch_DcosIo_DcosLaunch=%3Cdefault%3E) were run and

  - [ ] AWS Cloudformation Simple (link to job: )
  - [ ] Azure Resource Manager (link to job: )
  - [ ] Onprem-AWS (link to job: )
  - [ ] Onprem-GCE (link to job: )

**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs should have two approved [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.
